### PR TITLE
lazy initialization of handles for streams

### DIFF
--- a/test/bench_groups.lua
+++ b/test/bench_groups.lua
@@ -1,0 +1,22 @@
+require 'cudnn'
+
+m = cudnn.SpatialConvolution(512,512,13,13,1,1,1,1,512)
+
+
+inp = torch.zeros(1,512,512,512)
+
+inp = inp:cuda()
+m = m:cuda()
+
+cutorch.reserveStreams(10)
+-- cutorch.setStream(2) -- disables groups parallelization
+
+local tm = os.clock()
+for i=1,10 do
+   o=m:forward(inp)
+   cutorch.synchronize()
+   print(os.clock() - tm)
+   tm = os.clock()
+end
+
+print(#o)


### PR DESCRIPTION
earlier, 1024 cudnn handles were initialized at "require 'cudnn'" for streams. this added an overhead of like 300MB or so. Now handles are initialized lazily, as needed. The overhead goes down to less than 1MB