### PR TITLE
Fixed calling reset() twice 

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -5,7 +5,10 @@ local errcheck = cudnn.errcheck
 
 function SpatialConvolution:__init(nInputPlane, nOutputPlane,
                             kW, kH, dW, dH, padW, padH, groups)
+   local delayedReset = self.reset
+   self.reset = function() end
    parent.__init(self, nInputPlane, nOutputPlane, kW, kH, dW, dH)
+   self.reset = delayedReset
    self.padW = padW or 0
    self.padH = padH or 0
    self.groups = groups or 1

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -11,7 +11,6 @@ function VolumetricConvolution:__init(nInputPlane, nOutputPlane,
    self.padT = padT or 0
    self.padW = padW or 0
    self.padH = padH or 0
-   self:reset()
    self.iSize = torch.LongStorage(5):fill(0)
 end
 


### PR DESCRIPTION
This saves time and makes weights initialized as in the corresponding nn modules (random generator iterates the same number of steps)