### PR TITLE
adding proper documentation for new modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,28 @@ cudnn.VolumetricMaxPooling(kT, kW, kH, dT, dW, dH, padT, padW, padH)
 cudnn.VolumetricAveragePooling(kT, kW, kH, dT, dW, dH, padT, padW, padH)
 ```
 
-I have no time to support these, so please don't expect a quick response to filed github issues.
+### Modes
+There are two globally availabe modes useful for tuning performance:
+```lua
+require 'cudnn'
+cudnn.benchmark = true -- uses the inbuilt cudnn auto-tuner to find the fastest convolution algorithms.
+                       -- If this is set to false, uses some in-built heuristics that might not always be fastest.
+```
+by default `cudnn.benchmark` is set to `false`.
 
+```lua
+cudnn.fastest = true -- this is like the :fastest() mode for the Convolution modules,
+                     -- simply picks the fastest convolution algorithm, rather than tuning for workspace size
+```
+by default, `cudnn.fastest` is set to `false`.
+
+
+```lua
+cudnn.verbose = true -- this prints out some more verbose information useful for debugging
+```
+by default, `cudnn.verbose` is set to `false`.
+
+
+### Older versions
 For version CuDNN R1, checkout the branch **R1**
 For version CuDNN R2, checkout the branch **R2**

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -139,7 +139,9 @@ function SpatialConvolution:createIODescriptors(input)
         local algWorkspaceLimit = self.workspace_limit
             or (self.nInputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
 
-        if self.fastest_mode then algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST' end
+        if self.fastest_mode or cudnn.fastest == true then
+            algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST'
+        end
         if cudnn.benchmark then -- the manual auto-tuner is run
             local perfResults = ffi.new("cudnnConvolutionFwdAlgoPerf_t[?]", 1)
             local intt = torch.IntTensor(1);
@@ -175,7 +177,7 @@ function SpatialConvolution:createIODescriptors(input)
         local algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE'
         local algWorkspaceLimit = self.workspace_limit
             or (self.nInputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-        if self.fastest_mode then
+        if self.fastest_mode  or cudnn.fastest == true then
             algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST'
         end
 
@@ -214,7 +216,7 @@ function SpatialConvolution:createIODescriptors(input)
         local algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE'
         local algWorkspaceLimit = self.workspace_limit
             or (self.nInputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-        if self.fastest_mode then
+        if self.fastest_mode or cudnn.fastest == true then
             algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST'
         end
         if cudnn.benchmark then -- the manual auto-tuner is run

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -119,12 +119,14 @@ function VolumetricConvolution:createIODescriptors(input)
      local algSearchMode = 'CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT'
      local algWorkspaceLimit = self.workspace_limit
         or (self.nInputPlane * self.kT * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-     if self.fastest_mode then algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST' end
-         errcheck('cudnnGetConvolutionForwardAlgorithm',
-                  cudnn.getHandle(),
-                  self.iDesc[0], self.weightDesc[0],
-                  self.convDesc[0], self.oDesc[0],
-                  algSearchMode, algWorkspaceLimit, algType)
+     if self.fastest_mode  or cudnn.fastest == true then
+         algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST'
+     end
+     errcheck('cudnnGetConvolutionForwardAlgorithm',
+              cudnn.getHandle(),
+              self.iDesc[0], self.weightDesc[0],
+              self.convDesc[0], self.oDesc[0],
+              algSearchMode, algWorkspaceLimit, algType)
      algType[0] = self.fmode or algType[0]
          self.fwdAlgType = algType
          local bufSize = torch.LongTensor(1)
@@ -140,7 +142,9 @@ function VolumetricConvolution:createIODescriptors(input)
      local algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE'
      local algWorkspaceLimit = self.workspace_limit
         or (self.nInputPlane * self.kT * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-     if self.fastest_mode then algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST' end
+     if self.fastest_mode  or cudnn.fastest == true then
+         algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST'
+     end
          errcheck('cudnnGetConvolutionBackwardFilterAlgorithm',
                   cudnn.getHandle(),
                   self.iDesc[0], self.oDesc[0],
@@ -161,7 +165,9 @@ function VolumetricConvolution:createIODescriptors(input)
      local algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE'
      local algWorkspaceLimit = self.workspace_limit
         or (self.nInputPlane * self.kT * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-     if self.fastest_mode then algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST' end
+     if self.fastest_mode  or cudnn.fastest == true then
+         algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST'
+     end
          errcheck('cudnnGetConvolutionBackwardDataAlgorithm',
                   cudnn.getHandle(),
                   self.weightDesc[0], self.oDesc[0],

--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,8 @@ include 'ffi.lua'
 local C = cudnn.C
 local ffi = require 'ffi'
 
-cudnn.benchmark = true
+cudnn.benchmark = false
+cudnn.fastest = false
 
 local maxStreamsPerDevice = 1024
 local numDevices = cutorch.getDeviceCount()


### PR DESCRIPTION
### Modes
There are two globally availabe modes useful for tuning performance:
```lua
require 'cudnn'
cudnn.benchmark = true -- uses the inbuilt cudnn auto-tuner to find the fastest convolution algorithms.
                       -- If this is set to false, uses some in-built heuristics that might not always be fastest.
```
by default `cudnn.benchmark` is set to `false`.

```lua
cudnn.fastest = true -- this is like the :fastest() mode for the Convolution modules,
                     -- simply picks the fastest convolution algorithm, rather than tuning for workspace size
```
by default, `cudnn.fastest` is set to `false`.


```lua
cudnn.verbose = true -- this prints out some more verbose information useful for debugging
```
by default, `cudnn.verbose` is set to `false`.