### PR TITLE
Convolution's padH inconsistent with nn rock

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Modules are API compatible their [`nn`](https://github.com/torch/nn) equivalents
 
 ```lua
 -- All inputs have to be 3D or 4D(batch-mode), except ReLU, Tanh and Sigmoid
-cudnn.SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, [dW = 1], [dH = 1], [padW = 0], [padH = 0], [groups = 1])
+cudnn.SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, [dW = 1], [dH = 1], [padW = 0], [padH = padW], [groups = 1])
 cudnn.SpatialMaxPooling(kW, kH, dW, dH, padW, padH)
 cudnn.SpatialAveragePooling(kW, kH, dW, dH, padW, padH)
 

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -12,10 +12,8 @@ function SpatialConvolution:__init(nInputPlane, nOutputPlane,
                             kW, kH, dW, dH, padW, padH, groups)
     local delayedReset = self.reset
     self.reset = function() end
-    parent.__init(self, nInputPlane, nOutputPlane, kW, kH, dW, dH)
+    parent.__init(self, nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
     self.reset = delayedReset
-    self.padW = padW or 0
-    self.padH = padH or 0
     self.groups = groups or 1
     assert(nInputPlane % self.groups == 0,
            'nInputPlane should be divisible by nGroups')


### PR DESCRIPTION
Currently, the padH default value (0) is different from the one used in nn convolution modules (padW). The fix proposes to change this, albeit possibly harming backwards compatibility for cudnn users who adapted to this problem.