### PR TITLE
fix typo in SpatialConvolution

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -315,7 +315,7 @@ function SpatialConvolution:createIODescriptors(input)
         local kH, kW = self.kH, self.kW
         local oH, oW = oSize[3], oSize[4]
         self.input_offset = self.nInputPlane / self.groups * iH * iW
-        self.output_offset = self.nOutputPlane / self.groups * oH, oW
+        self.output_offset = self.nOutputPlane / self.groups * oH * oW
         self.weight_offset = self.nInputPlane / self.groups * self.nOutputPlane / self.groups * kH * kW
 
         if not batch then


### PR DESCRIPTION
It only has an impact if we use more than 1 group.
It would be complex to add a corresponding unit test since this option is not implemented in nn convolution.
Is this options really used btw?