### PR TITLE
nn <> cudnn conversion

### DIFF
--- a/Pointwise.lua
+++ b/Pointwise.lua
@@ -54,8 +54,12 @@ function Pointwise:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
-function Pointwise:write(f)
+function Pointwise:clearDesc()
    self.iDesc = nil
+end
+
+function Pointwise:write(f)
+   self:clearDesc()
    local var = {}
    for k,v in pairs(self) do
       var[k] = v

--- a/Pooling3D.lua
+++ b/Pooling3D.lua
@@ -124,10 +124,14 @@ function Pooling:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
-function Pooling:write(f)
+function Pooling:clearDesc()
    self.poolDesc = nil
    self.iDesc = nil
    self.oDesc = nil
+end
+
+function Pooling:write(f)
+   self:clearDesc()
    local var = {}
    for k,v in pairs(self) do
       var[k] = v

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ cudnn.torch
 Torch7 FFI bindings for NVidia CuDNN (R3) kernels!
 
 Modules are API compatible their [`nn`](https://github.com/torch/nn) equivalents. Fully unit-tested against `nn` implementations.
+Conversion between `nn` and `cudnn` is available through `cudnn.convert` function.
 
 #### Installation
 
@@ -59,6 +60,27 @@ cudnn.verbose = true -- this prints out some more verbose information useful for
 ```
 by default, `cudnn.verbose` is set to `false`.
 
+### Conversion between `cudnn` and `nn`
+
+Conversion is done by `cudnn.convert` function which takes a network and backend arguments and goes over
+network modules recursively substituting equivalents. No memory copy is done, just metatables are swapped.
+
+```lua
+net = nn.Sequential()
+net:add(nn.SpatialConvolution(3,96,11,11,3,3))
+net:add(nn.ReLU())
+cudnn.convert(net, cudnn)
+print(net)
+```
+
+will result in:
+```
+nn.Sequential {
+  [input -> (1) -> (2) -> output]
+  (1): cudnn.SpatialConvolution(3 -> 96, 11x11, 3,3)
+  (2): cudnn.ReLU
+}
+```
 
 ### Older versions
 For version CuDNN R1, checkout the branch **R1**

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -445,7 +445,7 @@ function SpatialConvolution:accGradParameters(input, gradOutput, scale)
     end
 end
 
-function SpatialConvolution:write(f)
+function SpatialConvolution:clearDesc()
     self.weightDesc = nil
     self.biasDesc = nil
     self.convDesc = nil
@@ -458,6 +458,11 @@ function SpatialConvolution:write(f)
     self.bwdFilterAlgType = nil
     self.extraBuffer = nil
     self.extraBufferSizeInBytes = nil
+    self.scaleT = nil
+end
+
+function SpatialConvolution:write(f)
+    self:clearDesc()
     local var = {}
     for k,v in pairs(self) do
         var[k] = v

--- a/SpatialCrossMapLRN.lua
+++ b/SpatialCrossMapLRN.lua
@@ -90,9 +90,13 @@ function LRN:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
-function LRN:write(f)
+function LRN:clearDesc()
    self.LRNDesc = nil
    self.iDesc = nil
+end
+
+function LRN:write(f)
+   self:clearDesc()
    local var = {}
    for k,v in pairs(self) do
       var[k] = v

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -264,7 +264,7 @@ function VolumetricConvolution:accGradParameters(input, gradOutput, scale)
         self.weightDesc[0], self.gradWeight:data());
 end
 
-function VolumetricConvolution:write(f)
+function VolumetricConvolution:clearDesc()
    self.weightDesc = nil
    self.biasDesc = nil
    self.convDesc = nil
@@ -276,6 +276,11 @@ function VolumetricConvolution:write(f)
    self.bwdFilterAlgType = nil
    self.extraBuffer = nil
    self.extraBufferInBytes = nil
+   self.scaleT = nil
+end
+
+function VolumetricConvolution:write(f)
+   self:clearDesc()
    local var = {}
    for k,v in pairs(self) do
       var[k] = v

--- a/convert.lua
+++ b/convert.lua
@@ -1,0 +1,62 @@
+-- modules that can be converted to nn seamlessly
+local layer_list = {
+  'SpatialConvolution',
+  'SpatialCrossMapLRN',
+  'SpatialMaxPooling',
+  'SpatialAveragePooling',
+  'ReLU',
+  'Tanh',
+  'Sigmoid',
+  'SoftMax',
+  'LogSoftMax',
+  'VolumetricConvolution',
+  'VolumetricMaxPooling',
+  'VolumetricAveragePooling',
+}
+
+-- similar to nn.Module.apply
+-- goes over a net and recursively replaces modules
+-- using callback function
+local function replace(self, callback)
+  local out = callback(self)
+  if self.modules then
+    for i, module in ipairs(self.modules) do
+      self.modules[i] = replace(module, callback)
+    end
+  end
+  return out
+end
+
+-- goes over a given net and converts all layers to dst backend
+-- for example: net = cudnn.convert(net, cudnn)
+function cudnn.convert(net, dst)
+  return replace(net, function(x)
+    local y = 0
+    local src = dst == nn and cudnn or nn
+    local src_prefix = src == nn and 'nn.' or 'cudnn.'
+    local dst_prefix = dst == nn and 'nn.' or 'cudnn.'
+
+    local function convert(v)
+      local y = {}
+      torch.setmetatable(y, dst_prefix..v)
+      if v == 'ReLU' then y = dst.ReLU() end -- because parameters
+      for k,u in pairs(x) do y[k] = u end
+      if src == cudnn and x.clearDesc then x:clearDesc() end
+      return y
+    end
+    local t = torch.typename(x)
+    if t == 'nn.SpatialConvolutionMM' then
+      y = convert('SpatialConvolution')
+    elseif t == 'inn.SpatialCrossResponseNormalization' then
+      y = convert('SpatialCrossMapLRN')
+    else
+      for i,v in ipairs(layer_list) do
+        if torch.typename(x) == src_prefix..v then
+          y = convert(v)
+        end
+      end
+    end
+    return y == 0 and x or y
+  end)
+end
+

--- a/init.lua
+++ b/init.lua
@@ -113,5 +113,6 @@ include 'SpatialCrossMapLRN.lua'
 include 'SpatialCrossEntropyCriterion.lua'
 
 include 'functional.lua'
+include 'convert.lua'
 
 return cudnn

--- a/test/test.lua
+++ b/test/test.lua
@@ -23,22 +23,38 @@ function cudnntest.SpatialConvolution_forward_batch()
    local outj = math.random(1,64)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
+
    local input = torch.randn(bs,from,inj,ini):cuda()
    local sconv = nn.SpatialConvolutionMM(from,to,ki,kj,si,sj):cuda()
-   local groundtruth = sconv:forward(input)
-   cutorch.synchronize()
    local gconv = cudnn.SpatialConvolution(from,to,ki,kj,si,sj):cuda():fastest()
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
-   local rescuda = gconv:forward(input)
-   cutorch.synchronize()
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
 
-   -- IO
-   local ferr,berr = jac.testIO(gconv, input)
-   mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
-   mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input)
+     cutorch.synchronize()
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+
+     local gconv = cudnn.convert(sconv, cudnn)
+     mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward conversion) ')
+
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 
@@ -75,20 +91,27 @@ function cudnntest.SpatialConvolution_backward_batch()
    torch.save('modelTemp.t7', gconv)
    gconv = torch.load('modelTemp.t7')
 
-   gconv:forward(input)
-   gconv:zeroGradParameters()
-   local rescuda = gconv:backward(input, gradOutput, scale)
-   cutorch.synchronize()
-   local weightcuda = gconv.gradWeight
-   local biascuda = gconv.gradBias
+   local function test(sconv, gconv)
+     gconv:forward(input)
+     gconv:zeroGradParameters()
+     local rescuda = gconv:backward(input, gradOutput, scale)
+     cutorch.synchronize()
+     local weightcuda = gconv.gradWeight
+     local biascuda = gconv.gradBias
 
-   local error = rescuda:float() - groundgrad:float()
-   local werror = weightcuda:float() - groundweight:float()
-   local berror = biascuda:float() - groundbias:float()
+     local error = rescuda:float() - groundgrad:float()
+     local werror = weightcuda:float() - groundweight:float()
+     local berror = biascuda:float() - groundbias:float()
 
-   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
-   mytester:assertlt(werror:abs():max(), precision_backward, 'error on weight (backward) ')
-   mytester:assertlt(berror:abs():max(), precision_backward, 'error on bias (backward) ')
+     mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+     mytester:assertlt(werror:abs():max(), precision_backward, 'error on weight (backward) ')
+     mytester:assertlt(berror:abs():max(), precision_backward, 'error on bias (backward) ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.SpatialConvolution_forward_single()
@@ -105,17 +128,37 @@ function cudnntest.SpatialConvolution_forward_single()
 
    local input = torch.randn(from,inj,ini):cuda()
    local sconv = nn.SpatialConvolutionMM(from,to,ki,kj,si,sj):cuda()
-   local groundtruth = sconv:forward(input)
-   cutorch.synchronize()
    local gconv = cudnn.SpatialConvolution(from,to,ki,kj,si,sj):cuda()
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
-   local rescuda = gconv:forward(input)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
+
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input)
+     cutorch.synchronize()
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward,
+                       'error on state (forward) ')
+
+     local gconv = cudnn.convert(sconv, cudnn)
+     mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward conversion) ')
+
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 
@@ -144,30 +187,38 @@ function cudnntest.SpatialConvolution_backward_single()
    local gconv = cudnn.SpatialConvolution(from,to,ki,kj,si,sj):cuda()
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
-   gconv:forward(input)
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+     gconv:forward(input)
 
-   gconv:forward(input)
-   gconv:zeroGradParameters()
-   local rescuda = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
-   local weightcuda = gconv.gradWeight
-   local biascuda = gconv.gradBias
+     -- serialize and deserialize
+     torch.save('modelTemp.t7', gconv)
+     gconv = torch.load('modelTemp.t7')
 
-   local error = rescuda:float() - groundgrad:float()
-   local werror = weightcuda:float() - groundweight:float()
-   local berror = biascuda:float() - groundbias:float()
+     gconv:forward(input)
+     gconv:zeroGradParameters()
+     local rescuda = gconv:backward(input, gradOutput)
+     cutorch.synchronize()
+     mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
+     local weightcuda = gconv.gradWeight
+     local biascuda = gconv.gradBias
 
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
-   mytester:assertlt(werror:abs():max(), precision_backward,
-                     'error on weight (backward) ')
-   mytester:assertlt(berror:abs():max(), precision_backward,
-                     'error on bias (backward) ')
+     local error = rescuda:float() - groundgrad:float()
+     local werror = weightcuda:float() - groundweight:float()
+     local berror = biascuda:float() - groundbias:float()
+
+     mytester:assertlt(error:abs():max(), precision_backward,
+                       'error on state (backward) ')
+     mytester:assertlt(werror:abs():max(), precision_backward,
+                       'error on weight (backward) ')
+     mytester:assertlt(berror:abs():max(), precision_backward,
+                       'error on bias (backward) ')
+  end
+
+  test(sconv, gconv)
+  local gconv = cudnn.convert(sconv, cudnn)
+  mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialConvolution', 'conversion type check') 
+  test(sconv, gconv)
 end
 
 function cudnntest.VolumetricConvolution_forward_single()
@@ -187,21 +238,30 @@ function cudnntest.VolumetricConvolution_forward_single()
    local ink = (outk-1)*sk+kk
    local input = torch.randn(from,ink,inj,ini):cuda()
    local sconv = nn.VolumetricConvolution(from,to,kk,ki,kj,sk,si,sj):float()
-   local groundtruth = sconv:forward(input:float())
-   cutorch.synchronize()
    local gconv = cudnn.VolumetricConvolution(from,to,kk,ki,kj,sk,si,sj):cuda()
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
-   local rescuda = gconv:forward(input)
-   cutorch.synchronize()
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
 
-   -- IO
-   local ferr,berr = jac.testIO(gconv, input)
-   mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
-   mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input:float())
+     cutorch.synchronize()
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward,
+                       'error on state (forward) ')
+
+     local gconv = cudnn.convert(sconv, cudnn):cuda()
+     local rescuda = gconv:forward(input)
+     cutorch.synchronize()
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward conversion) ')
+
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
 end
 
 function cudnntest.VolumetricConvolution_backward_single()
@@ -232,33 +292,40 @@ function cudnntest.VolumetricConvolution_backward_single()
    local gconv = cudnn.VolumetricConvolution(from,to,kk,ki,kj,sk,si,sj):cuda()
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
-   gconv:forward(input)
-   cutorch.synchronize()
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+     gconv:forward(input)
+     cutorch.synchronize()
 
-   gconv:forward(input)
-   gconv:zeroGradParameters()
-   local rescuda = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
+     -- serialize and deserialize
+     torch.save('modelTemp.t7', gconv)
+     gconv = torch.load('modelTemp.t7')
 
-   mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
-   local weightcuda = gconv.gradWeight
-   local biascuda = gconv.gradBias
+     gconv:forward(input)
+     gconv:zeroGradParameters()
+     local rescuda = gconv:backward(input, gradOutput)
+     cutorch.synchronize()
 
-   local error = rescuda:float() - groundgrad:float()
-   local werror = weightcuda:float() - groundweight:float()
-   local berror = biascuda:float() - groundbias:float()
+     mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
+     local weightcuda = gconv.gradWeight
+     local biascuda = gconv.gradBias
 
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
-   mytester:assertlt(werror:abs():max(), precision_backward,
-                     'error on weight (backward) ')
-   mytester:assertlt(berror:abs():max(), precision_backward,
-                     'error on bias (backward) ')
+     local error = rescuda:float() - groundgrad:float()
+     local werror = weightcuda:float() - groundweight:float()
+     local berror = biascuda:float() - groundbias:float()
 
+     mytester:assertlt(error:abs():max(), precision_backward,
+                       'error on state (backward) ')
+     mytester:assertlt(werror:abs():max(), precision_backward,
+                       'error on weight (backward) ')
+     mytester:assertlt(berror:abs():max(), precision_backward,
+                       'error on bias (backward) ')
+  end
+
+  test(sconv, gconv)
+  local gconv = cudnn.convert(sconv, cudnn):cuda()
+  mytester:asserteq(torch.typename(gconv), 'cudnn.VolumetricConvolution', 'conversion type check') 
+  test(sconv, gconv)
 end
 
 function cudnntest.VolumetricMaxPooling_batch()
@@ -280,28 +347,34 @@ function cudnntest.VolumetricMaxPooling_batch()
    local gradOutput = torch.randn(bs,from,outk,outj,outi):cuda()
 
    local sconv = nn.VolumetricMaxPooling(kk,ki,kj,sk,si,sj):float()
-   local groundtruth = sconv:forward(input:float())
-   local groundgrad = sconv:backward(input:float(), gradOutput:float())
-   cutorch.synchronize()
    local gconv = cudnn.VolumetricMaxPooling(kk,ki,kj,sk,si,sj):cuda()
-   local rescuda = gconv:forward(input)
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 5, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 5, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
 
-   -- IO
-   local ferr,berr = jac.testIO(gconv, input)
-   mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
-   mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input:float())
+     local groundgrad = sconv:backward(input:float(), gradOutput:float())
+     cutorch.synchronize()
+
+     local rescuda = gconv:forward(input)
+     local resgrad = gconv:backward(input, gradOutput)
+     cutorch.synchronize()
+
+     mytester:asserteq(rescuda:dim(), 5, 'error in dimension')
+     mytester:asserteq(resgrad:dim(), 5, 'error in dimension')
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+     error = resgrad:float() - groundgrad:float()
+     mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn):cuda()
+   mytester:asserteq(torch.typename(gconv), 'cudnn.VolumetricMaxPooling', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.VolumetricMaxPooling_single()
@@ -322,25 +395,33 @@ function cudnntest.VolumetricMaxPooling_single()
    local gradOutput = torch.randn(from,outk,outj,outi):cuda()
 
    local sconv = nn.VolumetricMaxPooling(kk,ki,kj,sk,si,sj):float()
-   local groundtruth = sconv:forward(input:float())
-   local groundgrad = sconv:backward(input:float(), gradOutput:float())
-   cutorch.synchronize()
    local gconv = cudnn.VolumetricMaxPooling(kk,ki,kj,sk,si,sj):cuda()
-   local _ = gconv:forward(input)
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input:float())
+      local groundgrad = sconv:backward(input:float(), gradOutput:float())
+      cutorch.synchronize()
+      local _ = gconv:forward(input)
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
+      local rescuda = gconv:forward(input)
+      local resgrad = gconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
+      mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
+      local error = rescuda:float() - groundtruth:float()
+      mytester:assertlt(error:abs():max(), precision_forward,
+                        'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      mytester:assertlt(error:abs():max(), precision_backward,
+                        'error on state (backward) ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn):cuda()
+   mytester:asserteq(torch.typename(gconv), 'cudnn.VolumetricMaxPooling', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.SpatialMaxPooling_batch()
@@ -405,26 +486,34 @@ function cudnntest.SpatialMaxPooling_single()
 
    local sconv = nn.SpatialMaxPooling(ki,kj,si,sj,padi,padj):cuda()
    if ceil_mode then sconv:ceil() end
-   local groundtruth = sconv:forward(input)
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
    local gconv = cudnn.SpatialMaxPooling(ki,kj,si,sj,padi,padj):cuda()
    if ceil_mode then gconv:ceil() end
-   local _ = gconv:forward(input)
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input)
+      local groundgrad = sconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      local _ = gconv:forward(input)
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
+      local rescuda = gconv:forward(input)
+      local resgrad = gconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
+      mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
+      local error = rescuda:float() - groundtruth:float()
+      mytester:assertlt(error:abs():max(), precision_forward,
+                        'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      mytester:assertlt(error:abs():max(), precision_backward,
+                        'error on state (backward) ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn):cuda()
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialMaxPooling', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.SpatialAveragePooling_batch()
@@ -480,25 +569,33 @@ function cudnntest.SpatialAveragePooling_single()
    local gradOutput = torch.randn(from,outj,outi):cuda()
 
    local sconv = nn.SpatialAveragePooling(ki,kj,si,sj):cuda()
-   local groundtruth = sconv:forward(input):clone()
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
    local gconv = cudnn.SpatialAveragePooling(ki,kj,si,sj):cuda()
-   local _ = gconv:forward(input)
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input):clone()
+      local groundgrad = sconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      local _ = gconv:forward(input)
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
+      local rescuda = gconv:forward(input)
+      local resgrad = gconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
+      mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
+      local error = rescuda:float() - groundtruth:float()
+      mytester:assertlt(error:abs():max(), precision_forward,
+                        'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      mytester:assertlt(error:abs():max(), precision_backward,
+                        'error on state (backward) ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn):cuda()
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialAveragePooling', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 local function nonlinSingle(nonlin)
@@ -511,35 +608,47 @@ local function nonlinSingle(nonlin)
    local gradOutput = torch.randn(from,outj,outi):cuda()
 
    local sconv = nn[nonlin]():cuda()
-   local groundtruth = sconv:forward(input)
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   -- 50% prob to choose inplace or out-of-place
-   local inplace = false
-   if math.random(0,1) == 1 then
-      inplace = true
-   end
    local gconv = cudnn[nonlin](inplace):cuda()
-   local input__ = input:clone()
-   local _ = gconv:forward(input__)
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input)
+     local groundgrad = sconv:backward(input, gradOutput)
+     cutorch.synchronize()
+     -- 50% prob to choose inplace or out-of-place
+     local inplace = false
+     if math.random(0,1) == 1 then
+        inplace = true
+     end
+     local input__ = input:clone()
+     local _ = gconv:forward(input__)
 
-   local input__ = input:clone()
-   local gradOutput__ = gradOutput:clone()
-   local rescuda = gconv:forward(input__)
-   local resgrad = gconv:backward(input__, gradOutput__)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+     -- serialize and deserialize
+     torch.save('modelTemp.t7', gconv)
+     gconv = torch.load('modelTemp.t7')
+
+     local input__ = input:clone()
+     local gradOutput__ = gradOutput:clone()
+     local rescuda = gconv:forward(input__)
+     local resgrad = gconv:backward(input__, gradOutput__)
+     cutorch.synchronize()
+     mytester:asserteq(rescuda:dim(), 3, 'error in dimension')
+     mytester:asserteq(resgrad:dim(), 3, 'error in dimension')
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward,
+                       'error on state (forward) ')
+     error = resgrad:float() - groundgrad:float()
+     mytester:assertlt(error:abs():max(), precision_backward,
+                       'error on state (backward) ')
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.'..nonlin, 'conversion type check') 
+   test(sconv, gconv)
 end
 
 local function nonlinBatch(nonlin)
@@ -553,43 +662,55 @@ local function nonlinBatch(nonlin)
    local gradOutput = torch.randn(bs,from,outj,outi):cuda()
 
    local sconv = nn[nonlin]():cuda()
-   local groundtruth = sconv:forward(input)
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   -- 50% prob to choose inplace or out-of-place
-   local inplace = false
-   if math.random(0,1) == 1 then
-      inplace = true
-   end
    local gconv = cudnn[nonlin](inplace):cuda()
-   local input__ = input:clone()
-   local rescuda = gconv:forward(input__)
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input)
+      local groundgrad = sconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      -- 50% prob to choose inplace or out-of-place
+      local inplace = false
+      if math.random(0,1) == 1 then
+         inplace = true
+      end
+      local input__ = input:clone()
+      local rescuda = gconv:forward(input__)
 
-   local input__ = input:clone()
-   local gradOutput__ = gradOutput:clone()
-   local rescuda = gconv:forward(input__)
-   local resgrad = gconv:backward(input__, gradOutput__)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
+
+      local input__ = input:clone()
+      local gradOutput__ = gradOutput:clone()
+      local rescuda = gconv:forward(input__)
+      local resgrad = gconv:backward(input__, gradOutput__)
+      cutorch.synchronize()
+      mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
+      mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
+      local error = rescuda:float() - groundtruth:float()
+      mytester:assertlt(error:abs():max(), precision_forward,
+                        'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      mytester:assertlt(error:abs():max(), precision_backward,
+                        'error on state (backward) ')
+     -- IO
+     local ferr,berr = jac.testIO(gconv, input)
+     mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+     mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.'..nonlin, 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.ReLU_single()
-   nonlinSingle('ReLU')
+nonlinSingle('ReLU')
 end
 
 function cudnntest.ReLU_batch()
-   nonlinBatch('ReLU')
+nonlinBatch('ReLU')
 end
 
 function cudnntest.Tanh_single()
@@ -626,24 +747,31 @@ function cudnntest.SpatialCrossMapLRN_batch()
    local sconv = nn.SpatialCrossMapLRN(size, alpha, beta, k):cuda()
    local gconv = cudnn.SpatialCrossMapLRN(size, alpha, beta, k):cuda()
 
-   local groundtruth = sconv:forward(input):clone()
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   gconv:forward(input)
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(), precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(), precision_backward,
-                     'error on state (backward) ')
+   local function test(sconv, gconv)
+     local groundtruth = sconv:forward(input):clone()
+     local groundgrad = sconv:backward(input, gradOutput)
+     cutorch.synchronize()
+     gconv:forward(input)
+     -- serialize and deserialize
+     torch.save('modelTemp.t7', gconv)
+     gconv = torch.load('modelTemp.t7')
+     local rescuda = gconv:forward(input)
+     local resgrad = gconv:backward(input, gradOutput)
+     cutorch.synchronize()
+     mytester:asserteq(rescuda:dim(), 4, 'error in dimension')
+     mytester:asserteq(resgrad:dim(), 4, 'error in dimension')
+     local error = rescuda:float() - groundtruth:float()
+     mytester:assertlt(error:abs():max(), precision_forward,
+                       'error on state (forward) ')
+     error = resgrad:float() - groundgrad:float()
+     mytester:assertlt(error:abs():max(), precision_backward,
+                       'error on state (backward) ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.SpatialCrossMapLRN', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 
@@ -747,27 +875,39 @@ function cudnntest.LogSoftMax_single()
    local gradOutput = torch.randn(sz):cuda()
 
    local sconv = nn.LogSoftMax():cuda()
-   local groundtruth = sconv:forward(input)
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
    local gconv = cudnn.LogSoftMax():cuda()
-   local _ = gconv:forward(input)
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input)
+      local groundgrad = sconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      local _ = gconv:forward(input)
 
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   local error = rescuda:float() - groundtruth:float()
-   local errmax = error:abs():max()
-   mytester:assertlt(errmax, precision_forward,
-                     'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   errmax = error:abs():max()
-   mytester:assertlt(errmax, precision_backward,
-                     'error on state (backward) ')
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
+
+      local rescuda = gconv:forward(input)
+      local resgrad = gconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      local error = rescuda:float() - groundtruth:float()
+      local errmax = error:abs():max()
+      mytester:assertlt(errmax, precision_forward,
+                        'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      errmax = error:abs():max()
+      mytester:assertlt(errmax, precision_backward,
+                        'error on state (backward) ')
+      -- IO
+      local ferr,berr = jac.testIO(gconv, input)
+      mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+      mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.LogSoftMax', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.LogSoftMax_batch()
@@ -777,33 +917,41 @@ function cudnntest.LogSoftMax_batch()
    local gradOutput = torch.randn(bs,from):cuda()
 
    local sconv = nn.LogSoftMax():cuda()
-   local groundtruth = sconv:forward(input)
-   local groundgrad = sconv:backward(input, gradOutput)
-   cutorch.synchronize()
    local gconv = cudnn.LogSoftMax():cuda()
-   local rescuda = gconv:forward(input)
 
-   -- serialize and deserialize
-   torch.save('modelTemp.t7', gconv)
-   gconv = torch.load('modelTemp.t7')
+   local function test(sconv, gconv)
+      local groundtruth = sconv:forward(input)
+      local groundgrad = sconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      local rescuda = gconv:forward(input)
 
-   local rescuda = gconv:forward(input)
-   local resgrad = gconv:backward(input, gradOutput)
-   cutorch.synchronize()
-   mytester:asserteq(rescuda:dim(), 2, 'error in dimension')
-   mytester:asserteq(resgrad:dim(), 2, 'error in dimension')
+      -- serialize and deserialize
+      torch.save('modelTemp.t7', gconv)
+      gconv = torch.load('modelTemp.t7')
 
-   local error = rescuda:float() - groundtruth:float()
-   mytester:assertlt(error:abs():max(),
-                     precision_forward, 'error on state (forward) ')
-   error = resgrad:float() - groundgrad:float()
-   mytester:assertlt(error:abs():max(),
-                     precision_backward, 'error on state (backward) ')
+      local rescuda = gconv:forward(input)
+      local resgrad = gconv:backward(input, gradOutput)
+      cutorch.synchronize()
+      mytester:asserteq(rescuda:dim(), 2, 'error in dimension')
+      mytester:asserteq(resgrad:dim(), 2, 'error in dimension')
 
-   -- IO
-   local ferr,berr = jac.testIO(gconv, input)
-   mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
-   mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+      local error = rescuda:float() - groundtruth:float()
+      mytester:assertlt(error:abs():max(),
+                        precision_forward, 'error on state (forward) ')
+      error = resgrad:float() - groundgrad:float()
+      mytester:assertlt(error:abs():max(),
+                        precision_backward, 'error on state (backward) ')
+
+      -- IO
+      local ferr,berr = jac.testIO(gconv, input)
+      mytester:assertlt(ferr, precision_io, torch.typename(gconv) .. ' - i/o forward err ')
+      mytester:assertlt(berr, precision_io, torch.typename(gconv) .. ' - i/o backward err ')
+   end
+
+   test(sconv, gconv)
+   local gconv = cudnn.convert(sconv, cudnn)
+   mytester:asserteq(torch.typename(gconv), 'cudnn.LogSoftMax', 'conversion type check') 
+   test(sconv, gconv)
 end
 
 function cudnntest.SpatialLogSoftMax()


### PR DESCRIPTION
Easy conversion function:
```lua
net = cudnn.convert(net, cudnn)
```
will go recursively over a network and substitute all compatible layers to a given backend. The parameters are not cloned, only references are copied.

Going to add some tests, tested locally so far.