### PR TITLE
Fixed wrong detection of tensor size 1/x/y/z = x/y/z

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -83,17 +83,19 @@ function SpatialConvolution:resetMode()
 end
 
 function SpatialConvolution:createIODescriptors(input)
-    local batch = true
-    if input:dim() == 3 then
-        input = input:view(1, input:size(1), input:size(2), input:size(3))
-        batch = false
-    end
-    assert(input:dim() == 4 and input:isContiguous());
-    self.iSize = self.iSize or torch.LongStorage(4):fill(0)
+    assert((input:dim() == 3 or input:dim() == 4) and input:isContiguous());
+
     if not self.iDesc or not self.oDesc or
-        input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-    or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
+        input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2] or
+        input:size(3) ~= self.iSize[3] or
+        (#input:size() == 4 and #self.iSize == 4 and
+         input:size(4) ~= self.iSize[4]) then
         self.iSize = input:size()
+        local batch = true
+        if input:dim() == 3 then
+            input = input:view(1, input:size(1), input:size(2), input:size(3))
+            batch = false
+        end
 
         -- resize gradInput
         if self.gradInput then self.gradInput:resizeAs(input); end

--- a/test/test.lua
+++ b/test/test.lua
@@ -221,6 +221,15 @@ function cudnntest.SpatialConvolution_backward_single()
   test(sconv, gconv)
 end
 
+function cudnntest.SpatialConvolution_batch_reshape()
+   local gconv = cudnn.SpatialConvolution(4, 8, 4, 4, 2, 2):cuda()
+   local outputBatch = gconv:forward(torch.rand(1, 4, 32, 32):cuda())
+   mytester:asserteq(outputBatch:dim(), 4, 'error in dimension')
+
+   local outputNoBatch = gconv:forward(torch.rand(4, 32, 32):cuda())
+   mytester:asserteq(outputNoBatch:dim(), 3, 'error in dimension')
+end
+
 function cudnntest.VolumetricConvolution_forward_single()
    local from = math.random(1,16)
    local to = math.random(1,16)


### PR DESCRIPTION
Problem manifests when using the module in succession with tensors of sizes 1/x/y/z and x/y/z. In the second run the module behaves as if it were fed with a tensor with batch dimension and size 1.