### PR TITLE
Fix SpatialBatchNormalization compatibility between cudnn and nn

### DIFF
--- a/SpatialBatchNormalization.lua
+++ b/SpatialBatchNormalization.lua
@@ -90,7 +90,7 @@ function SpatialBatchNormalization:write(f)
 end
 
 function SpatialBatchNormalization:read(file, version)
-   parent.read(self, file)
+   parent.read(self, file, version)
    if version < 2 then
       if self.running_std then
          -- for models before https://github.com/soumith/cudnn.torch/pull/101


### PR DESCRIPTION
Version argument is missing at cudnn/SpatialBatchNormalization.lua:93 while calling
```
function BN:read(file, version)
```
at nn/SpatialBatchNormalization.lua:136.

````
~/libraries/install/torch/install/bin/luajit: ...h/install/share/lua/5.1/nn/SpatialBatchNormalization.lua:136: attempt to compare nil with number
stack traceback:
	...h/install/share/lua/5.1/nn/SpatialBatchNormalization.lua:136: in function 'read'
	...nstall/share/lua/5.1/cudnn/SpatialBatchNormalization.lua:93: in function 'read'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:342: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:344: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:344: in function 'readObject'
	...
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:344: in function 'readObject'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:360: in function 'readObject'
	.../install/torch/install/share/lua/5.1/nngraph/gmodule.lua:425: in function 'read'
	...aries/install/torch/install/share/lua/5.1/torch/File.lua:342: in function 'readObject'
	...raries/install/torch/install/share/lua/5.1/nn/Module.lua:108: in function 'clone'
	train_net.lua:350: in main chunk
	[C]: in function 'dofile'
	...tall/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
	[C]: at 0x00405be0
```