### PR TITLE
SpatialBatchNormalization: init of weights and bias missing?

### DIFF
--- a/SpatialBatchNormalization.lua
+++ b/SpatialBatchNormalization.lua
@@ -122,3 +122,8 @@ function SpatialBatchNormalization:clearState()
    nn.utils.clear(self, 'save_mean', 'save_std')
    return parent.clearState(self)
 end
+
+function SpatialBatchNormalization:reset()
+   self.weight:uniform()
+   self.bias:zero()
+end


### PR DESCRIPTION
I am not able to run with images, i only have 3D data handy. But I don't think the weights and bias were initialized before? Feel free to close and ignore if this isn't the case...