### PR TITLE
fix cudnn -> nn avg-pooling conversion

### DIFF
--- a/convert.lua
+++ b/convert.lua
@@ -42,6 +42,7 @@ function cudnn.convert(net, dst)
       if v == 'ReLU' then y = dst.ReLU() end -- because parameters
       for k,u in pairs(x) do y[k] = u end
       if src == cudnn and x.clearDesc then x:clearDesc() end
+      if src == cudnn and v == 'SpatialAveragePooling' then y.divide = true end
       return y
     end
     local t = torch.typename(x)


### PR DESCRIPTION
cudnn to nn conversion was broken for avg-pooling as cudnn didn't have divide field and nn was assuming it was set to false.
needed to convert fb.resnet networks to nn

I need to add tests for cudnn -> nn conversion to avoid this kind of bugs.