### PR TITLE
Check if padW and padH exist in SpatialConvolution

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -120,6 +120,7 @@ function SpatialConvolution:createIODescriptors(input)
         -- create conv descriptor
         self.convDesc = ffi.new('struct cudnnConvolutionStruct*[1]')
         errcheck('cudnnCreateConvolutionDescriptor', self.convDesc)
+        self.padH, self.padW = self.padH or 0, self.padW or 0
         local pad = torch.IntTensor({self.padH, self.padW})
         local stride = torch.IntTensor({self.dH, self.dW})
         local upscale = torch.IntTensor({1,1})


### PR DESCRIPTION
Older nn networks don't have it and cudnn.convert segfaults