### PR TITLE
fix bias in SpatialConvolution

### DIFF
--- a/convert.lua
+++ b/convert.lua
@@ -42,6 +42,10 @@ function cudnn.convert(net, dst)
       if v == 'ReLU' then y = dst.ReLU() end -- because parameters
       for k,u in pairs(x) do y[k] = u end
       if src == cudnn and x.clearDesc then x:clearDesc() end
+      if v == 'SpatialConvolution' and y.bias == nil then
+        y.bias = torch.zeros(y.nOutputPlane):typeAs(y.weight)
+        y.gradBias = torch.Tensor():typeAs(y.bias):resizeAs(y.bias):zero()
+      end
       return y
     end
     local t = torch.typename(x)


### PR DESCRIPTION
Hi,

This PR fixes a problem with the `convert` function. 
`cudnn.SpatialConvolution` allows the layer to have no bias, whereas  `nn.SpatialConvolution` must have a bias even if it's zero.
This PR inserts a dummy bias when a `cudnn.SpatialConvolution` layer without bias is converted into `nn.SpatialConvolution` layer, so that the resulted layer can work.

I'm a little confused since cudnn.torch has so many branches, will this fix the problem in branches other than `R4`?