### PR TITLE
[R5] cudnn.convert for BatchNorm

### DIFF
--- a/BatchNormalization.lua
+++ b/BatchNormalization.lua
@@ -118,6 +118,16 @@ function BatchNormalization:clearDesc()
    self.sDesc = nil
 end
 
+function BatchNormalization:read(file, version)
+   parent.read(self, file)
+   if version < 2 then
+      if self.running_std then
+         self.running_var = self.running_std:pow(-2):add(-self.eps)
+         self.running_std = nil
+      end
+   end
+end
+
 function BatchNormalization:write(f)
    self:clearDesc()
    local var = {}

--- a/convert.lua
+++ b/convert.lua
@@ -1,5 +1,7 @@
 -- modules that can be converted to nn seamlessly
 local layer_list = {
+  'BatchNormalization',
+  'SpatialBatchNormalization',
   'SpatialConvolution',
   'SpatialCrossMapLRN',
   'SpatialFullConvolution',
@@ -10,6 +12,7 @@ local layer_list = {
   'Sigmoid',
   'SoftMax',
   'LogSoftMax',
+  'VolumetricBatchNormalization',
   'VolumetricConvolution',
   'VolumetricMaxPooling',
   'VolumetricAveragePooling',


### PR DESCRIPTION
It seems to me at first that this should have been difficult, but as there are read methods in `nn` and `cudnn` there is nothing else needed for backward compatibility except what cudnn.convert does by default.
Added tests for nn2cudnn cudnn2nn conversions too, and checks that running_mean and running_var are the same in `nn` and `cudnn`.