### PR TITLE
Fixed error with batchFirst assertion

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -360,14 +360,18 @@ function RNN:updateGradInput(input, gradOutput)
     if (self.batchFirst) then
         input = input:transpose(1, 2)
         gradOutput = gradOutput:transpose(1, 2)
-        self.output = self.output:transpose(1, 2)
     end
    assert(input:dim() == 3, 'input should have 3 dimensions: seqLength, miniBatch, inputSize')
    assert(input:size(1) == self.seqLength, 'input has incorrect sequence length!')
    assert(input:size(2) == self.miniBatch, 'input has incorrect minibatch size!')
    assert(input:size(3) == self.inputSize, 'input has incorrect size!')
 
-   assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
+    if (self.batchFirst) then
+        assert(gradOutput:isSameSizeAs(self.output:transpose(1, 2)), 'gradOutput has incorrect size!')
+
+    else
+        assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
+    end
    assert(self.train, 'updateGradInput can only be called when training!')
 
    local x, dy = self:makeContiguous(input, gradOutput)
@@ -450,7 +454,12 @@ function RNN:accGradParameters(input, gradOutput, scale)
    assert(input:size(2) == self.miniBatch, 'input has incorrect minibatch size!')
    assert(input:size(3) == self.inputSize, 'input has incorrect size!')
 
-   assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
+    if (self.batchFirst) then
+        assert(gradOutput:isSameSizeAs(self.output:transpose(1, 2)), 'gradOutput has incorrect size!')
+
+    else
+        assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
+    end
    assert(self.train, 'accGradParameters can only be called when training!')
 
    local x, dy = self:makeContiguous(input, gradOutput)

--- a/RNN.lua
+++ b/RNN.lua
@@ -213,7 +213,7 @@ function RNN:resetCellDescriptors()
 end
 
 function RNN:makeContiguous(input, gradOutput)
-   if not input:isContiguous() then
+   if input and not input:isContiguous() then
       self._input = self._input or input.new()
       self._input:typeAs(input):resizeAs(input):copy(input)
       input = self._input
@@ -368,7 +368,7 @@ function RNN:updateGradInput(input, gradOutput)
    assert(self.train, 'updateGradInput can only be called when training!')
    local expectedSize = torch.LongStorage {self.seqLength, self.miniBatch, self.hiddenSize * self.numDirections}
    assert(gradOutput:isSize(expectedSize), 'gradOutput has incorrect size!')
-   local x, dy = self:makeContiguous(input, gradOutput)
+   local x, dy = self:makeContiguous(nil, gradOutput) -- No need to calculate x.
    local y = self.output
    local w = self.weight
    local dx = self.gradInput:resizeAs(input)

--- a/RNN.lua
+++ b/RNN.lua
@@ -365,15 +365,9 @@ function RNN:updateGradInput(input, gradOutput)
    assert(input:size(1) == self.seqLength, 'input has incorrect sequence length!')
    assert(input:size(2) == self.miniBatch, 'input has incorrect minibatch size!')
    assert(input:size(3) == self.inputSize, 'input has incorrect size!')
-
-    if (self.batchFirst) then
-        assert(gradOutput:isSameSizeAs(self.output:transpose(1, 2)), 'gradOutput has incorrect size!')
-
-    else
-        assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
-    end
    assert(self.train, 'updateGradInput can only be called when training!')
-
+   local expectedSize = torch.LongStorage {self.seqLength, self.miniBatch, self.hiddenSize * self.numDirections}
+   assert(gradOutput:isSize(expectedSize), 'gradOutput has incorrect size!')
    local x, dy = self:makeContiguous(input, gradOutput)
    local y = self.output
    local w = self.weight

--- a/RNN.lua
+++ b/RNN.lua
@@ -447,13 +447,8 @@ function RNN:accGradParameters(input, gradOutput, scale)
    assert(input:size(1) == self.seqLength, 'input has incorrect sequence length!')
    assert(input:size(2) == self.miniBatch, 'input has incorrect minibatch size!')
    assert(input:size(3) == self.inputSize, 'input has incorrect size!')
-
-    if (self.batchFirst) then
-        assert(gradOutput:isSameSizeAs(self.output:transpose(1, 2)), 'gradOutput has incorrect size!')
-
-    else
-        assert(gradOutput:isSameSizeAs(self.output), 'gradOutput has incorrect size!')
-    end
+   local expectedSize = torch.LongStorage {self.seqLength, self.miniBatch, self.hiddenSize * self.numDirections}
+   assert(gradOutput:isSize(expectedSize), 'gradOutput has incorrect size!')
    assert(self.train, 'accGradParameters can only be called when training!')
 
    local x, dy = self:makeContiguous(input, gradOutput)

--- a/RNN.lua
+++ b/RNN.lua
@@ -2,12 +2,6 @@ local RNN, parent = torch.class('cudnn.RNN', 'nn.Module')
 local ffi = require 'ffi'
 local errcheck = cudnn.errcheck
 
-RNN.linearLayers = {} -- Sizes of linear layers for weights/bias look up.
-RNN.linearLayers['CUDNN_LSTM'] = 8
-RNN.linearLayers['CUDNN_GRU'] = 6
-RNN.linearLayers['CUDNN_RNN_RELU'] = 2
-RNN.linearLayers['CUDNN_RNN_TANH'] = 2
-
 function RNN:__init(inputSize, hiddenSize, numLayers, batchFirst)
    parent.__init(self)
 
@@ -501,62 +495,6 @@ function RNN:accGradParameters(input, gradOutput, scale)
                self.dw:data(),
                scaleTensor:data())
    end
-end
-
-local function numberOfLinearLayers(self)
-    return RNN.linearLayers[self.mode]
-end
-
--- Function gets either the matrix or bias param depending on cuDNN method given, at each layer and linear layerId.
-local function retrieveLinearParams(self, cuDNNMethod)
-    local linearParams = {}
-    local numberOfLinearLayers = numberOfLinearLayers(self)
-
-    for layer = 0, self.numLayers - 1 do
-        local layerInfo = {}
-        for layerId = 0, numberOfLinearLayers - 1 do
-            local linLayerMatDesc = self:createFilterDescriptors(1)
-            local pointer = ffi.new("float*[1]")
-            errcheck(cuDNNMethod,
-                cudnn.getHandle(),
-                self.rnnDesc[0],
-                layer,
-                self.xDescs,
-                self.wDesc[0],
-                self.weight:data(),
-                layerId,
-                linLayerMatDesc[0],
-                ffi.cast("void**", pointer))
-
-            local dataType = 'CUDNN_DATA_FLOAT'
-            local format = 'CUDNN_TENSOR_NCHW'
-            local nbDims = torch.IntTensor(1)
-
-            local minDim = 3
-            local filterDimA = torch.ones(minDim):int()
-            errcheck('cudnnGetFilterNdDescriptor',
-                linLayerMatDesc[0],
-                minDim,
-                ffi.cast("cudnnDataType_t*", dataType),
-                ffi.cast("cudnnTensorFormat_t*", format),
-                nbDims:data(),
-                filterDimA:data())
-
-            local offset = pointer[0] - self.weight:data()
-            local params = torch.CudaTensor(self.weight:storage(), offset + 1, filterDimA:prod())
-            table.insert(layerInfo, params)
-        end
-        table.insert(linearParams, layerInfo)
-    end
-    return linearParams
-end
-
-function RNN:weights()
-    return retrieveLinearParams(self, 'cudnnGetRNNLinLayerMatrixParams')
-end
-
-function RNN:biases()
-    return retrieveLinearParams(self, 'cudnnGetRNNLinLayerBiasParams')
 end
 
 function RNN:clearDesc()


### PR DESCRIPTION
Hey,

Found an error when calling updateGradInput twice with batchFirst, problem can be replicated using this:
```
require 'cudnn'
blstm = cudnn.BLSTM(2,5,1,true)
input = torch.rand(6,3,2):cuda()
output = blstm:forward(input)
grad = blstm:updateGradInput(input,output)
grad = blstm:updateGradInput(input,output)
```