### PR TITLE
fp16 support

### DIFF
--- a/Pointwise.lua
+++ b/Pointwise.lua
@@ -31,11 +31,14 @@ function Pointwise:createIODescriptors(input)
    end
 
    local nElem = input:nElement()
-   self.nElem = self.nElem or nElem -- this goes to the second branch only once
-   if self.iDesc and nElem == self.nElem then return end
-   self.nElem = nElem
-   self.iDesc = cudnn.toDescriptor(input:view(1,1,1,nElem))
-
+   self.nElem = self.nElem or nElem
+   if self.iDesc and nElem == self.nElem and
+      self.iType and input:type() == self.iType then
+      return
+   else
+      self.nElem = nElem
+      self.iDesc = cudnn.toDescriptor(input:view(1,1,1,nElem))
+   end
 end
 
 local one = torch.FloatTensor({1});

--- a/Pooling.lua
+++ b/Pooling.lua
@@ -50,33 +50,36 @@ function Pooling:createIODescriptors(input)
    end
    assert(input:dim() == 4 and input:isContiguous());
    if not self.iDesc or not self.oDesc or
-      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-   or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
-      self.iSize = input:size()
-      -- resize gradInput
-      self.gradInput:resizeAs(input)
-      -- resize output
-      local oW, oH
-      if self.ceil_mode then
-         oW = math.ceil((input:size(4)+self.padW*2 - self.kW)/self.dW + 1)
-         oH = math.ceil((input:size(3)+self.padH*2 - self.kH)/self.dH + 1)
-      else
-         oW = math.floor((input:size(4)+self.padW*2 - self.kW)/self.dW + 1)
-         oH = math.floor((input:size(3)+self.padH*2 - self.kH)/self.dH + 1)
-      end
-      self.output:resize(input:size(1), input:size(2), oH, oW)
+      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2] or
+      input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] or 
+      not self.iType or input:type() ~= self.iType then
+         
+         self.iSize = input:size()
+         self.iType = input:type()
+         -- resize gradInput
+         self.gradInput:resizeAs(input)
+         -- resize output
+         local oW, oH
+         if self.ceil_mode then
+            oW = math.ceil((input:size(4)+self.padW*2 - self.kW)/self.dW + 1)
+            oH = math.ceil((input:size(3)+self.padH*2 - self.kH)/self.dH + 1)
+         else
+            oW = math.floor((input:size(4)+self.padW*2 - self.kW)/self.dW + 1)
+            oH = math.floor((input:size(3)+self.padH*2 - self.kH)/self.dH + 1)
+         end
+         self.output:resize(input:size(1), input:size(2), oH, oW)
 
-      -- create input/output descriptor
-      self.iDesc = cudnn.toDescriptor(input)
-      self.oDesc = cudnn.toDescriptor(self.output)
-      if not batch then
-         self.gradInput = self.gradInput:view(self.gradInput:size(2),
-                                              self.gradInput:size(3),
-                                              self.gradInput:size(4))
-         self.output = self.output:view(self.output:size(2),
-                                        self.output:size(3),
-                                        self.output:size(4))
-      end
+         -- create input/output descriptor
+         self.iDesc = cudnn.toDescriptor(input)
+         self.oDesc = cudnn.toDescriptor(self.output)
+         if not batch then
+            self.gradInput = self.gradInput:view(self.gradInput:size(2),
+                                                 self.gradInput:size(3),
+                                                 self.gradInput:size(4))
+            self.output = self.output:view(self.output:size(2),
+                                           self.output:size(3),
+                                           self.output:size(4))
+         end
    end
 end
 

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -374,8 +374,9 @@ local function makeContiguous(self, input, gradOutput)
 end
 
 function SpatialConvolution:updateOutput(input)
-    if not self.weightDesc or 
-    not self.weightType or self:type() ~= self.weightType then self:resetWeightDescriptors() end
+    if not self.weightDesc or not self.weightType or self:type() ~= self.weightType then 
+       self:resetWeightDescriptors() 
+    end
     input = makeContiguous(self, input)
     self:createIODescriptors(input)
 

--- a/SpatialCrossMapLRN.lua
+++ b/SpatialCrossMapLRN.lua
@@ -33,9 +33,12 @@ function LRN:createIODescriptors(input)
    end
    assert(input:dim() == 4 and input:isContiguous());
    if not self.iDesc or
-      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-   or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
+      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2] or
+      input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] or 
+   not self.iType or input:type() ~= self.iType then
+
       self.iSize = input:size()
+      self.iType = input:type()
       self.gradInput:resizeAs(input)
       self.output:resizeAs(input)
 

--- a/SpatialDivisiveNormalization.lua
+++ b/SpatialDivisiveNormalization.lua
@@ -32,10 +32,12 @@ function DivisiveNorm:createIODescriptors(input)
       batch = false
    end
    assert(input:dim() == 4 and input:isContiguous());
-   if not self.iDesc or
-      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-   or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
+   if not self.iDesc or not self.iType or input:type() ~= self.iType or
+      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2] or
+      input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
+      
       self.iSize = input:size()
+      self.iType = input:type()
       self.gradInput:resizeAs(input)
       self.output:resizeAs(input)
 

--- a/SpatialSoftMax.lua
+++ b/SpatialSoftMax.lua
@@ -15,6 +15,7 @@ function SpatialSoftMax:createIODescriptors(input)
    -- after converting from nn use accurate
    self.algorithm = self.algorithm or 'CUDNN_SOFTMAX_ACCURATE'
    self.iSize = self.iSize or torch.LongStorage(4):fill(0)
+   self.iType = self.iType or input:type()
 
    local batch = true
    local singleDim = false
@@ -32,9 +33,12 @@ function SpatialSoftMax:createIODescriptors(input)
    assert(input:dim() == 4 and input:isContiguous());
 
    if not self.iDesc or not self.oDesc or
-      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-   or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
+      input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2] or
+      input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] or
+      input:type() ~= self.iType then
+
       self.iSize = input:size()
+      self.iType = input:type()
       self.gradInput:resizeAs(input)
       self.output:resizeAs(input)
       self.iDesc = cudnn.toDescriptor(input)

--- a/init.lua
+++ b/init.lua
@@ -61,7 +61,17 @@ end
 cudnn.errcheck = errcheck
 
 function cudnn.toDescriptor(t)
-   assert(torch.typename(t) == 'torch.CudaTensor')
+   
+   local typeName = torch.typename(t)
+   local cudnnDataType
+   if typeName == 'torch.CudaTensor' then
+      cudnnDataType = 'CUDNN_DATA_FLOAT'
+   elseif typeName == 'torch.CudaHalfTensor' then
+      cudnnDataType = 'CUDNN_DATA_HALF'
+   else
+      assert(false, 'Only Cuda supported, duh!')
+   end
+
    local descriptor = ffi.new('struct cudnnTensorStruct*[1]')
    -- create descriptor
    errcheck('cudnnCreateTensorDescriptor', descriptor)
@@ -79,7 +89,7 @@ function cudnn.toDescriptor(t)
    -- set descriptor
    local size = torch.LongTensor(t:size()):int()
    local stride = torch.LongTensor(t:stride()):int()
-   errcheck('cudnnSetTensorNdDescriptor', descriptor[0], 'CUDNN_DATA_FLOAT',
+   errcheck('cudnnSetTensorNdDescriptor', descriptor[0], cudnnDataType,
             t:dim(), size:data(), stride:data())
    return descriptor
 end

--- a/test/test_fp16.lua
+++ b/test/test_fp16.lua
@@ -59,12 +59,27 @@ print('========== MaxPool ===========')
 print('==============================')
 print('')
 
-m = cudnn.SpatialMaxPooling
+m = cudnn.SpatialMaxPooling(2,2)
 
-function fwdReLU(x, datatype)
+function fwdMaxPool(x, datatype)
    x = x:clone():type(datatype)
    m = m:type(datatype)
    return m:forward(x):clone()
 end
-eval(torch.randn(1,3,25,27), fwdReLU)
+eval(torch.randn(1,3,25,27), fwdMaxPool)
+
+
+print('==============================')
+print('========== SoftMax ===========')
+print('==============================')
+print('')
+
+m = cudnn.SpatialSoftMax()
+
+function fwdSoftMax(x, datatype)
+   x = x:clone():type(datatype)
+   m = m:type(datatype)
+   return m:forward(x):clone()
+end
+eval(torch.randn(1,3,25,27), fwdSoftMax)
 

--- a/test/test_fp16.lua
+++ b/test/test_fp16.lua
@@ -2,24 +2,69 @@ require 'cudnn'
 require 'cunn'
 
 
-x = torch.randn(1,3,25,27)
+function eval(x, fwd)
+   print('=========== input ============')
+   print(x:sub(1,1, 1,3, 1,3, 1,3))
+
+   print('=========== single ===========')
+   y1 = fwd(x:clone(), 'torch.CudaTensor')
+   print(y1:sub(1,1, 1,3, 1,3, 1,3))
+   
+   print('============ half ============')
+   y2 = fwd(x:clone(), 'torch.CudaHalfTensor'):cuda()
+   print(y2:sub(1,1, 1,3, 1,3, 1,3))
+   
+   print('============ diff ============')
+   yDiff = y2-y1
+   print(yDiff:sub(1,1, 1,3, 1,3, 1,3))
+end
+
+
+
+
+
+print('==============================')
+print('===== SpatialConvolution =====')
+print('==============================')
+print('')
+
 m = cudnn.SpatialConvolution(3,16,7,7,1,1,3,3)
 
-function fwd(datatype)
+function fwdSpatialConv(x, datatype)
    x = x:type(datatype)
-   m:clearDesc()
+   --m:clearDesc()
    m = m:type(datatype)
    return m:forward(x):clone()
 end
+eval(torch.randn(1,3,25,27), fwdSpatialConv)
 
-print('=========== single ===========')
-y1 = fwd('torch.CudaTensor')
-print(y1:sub(1,1, 1,3, 1,3, 1,3))
 
-print('============ half ============')
-y2 = fwd('torch.CudaHalfTensor'):cuda()
-print(y2:sub(1,1, 1,3, 1,3, 1,3))
+print('==============================')
+print('============ ReLU ============')
+print('==============================')
+print('')
 
-print('============ diff ============')
-yDiff = y2-y1
-print(yDiff:sub(1,1, 1,3, 1,3, 1,3))
+m = cudnn.ReLU(true)
+
+function fwdReLU(x, datatype)
+   x = x:clone():type(datatype)
+   m = m:type(datatype)
+   return m:forward(x):clone()
+end
+eval(torch.randn(1,3,25,27), fwdReLU)
+
+
+print('==============================')
+print('========== MaxPool ===========')
+print('==============================')
+print('')
+
+m = cudnn.SpatialMaxPooling
+
+function fwdReLU(x, datatype)
+   x = x:clone():type(datatype)
+   m = m:type(datatype)
+   return m:forward(x):clone()
+end
+eval(torch.randn(1,3,25,27), fwdReLU)
+

--- a/test/test_fp16.lua
+++ b/test/test_fp16.lua
@@ -1,21 +1,25 @@
 require 'cudnn'
 require 'cunn'
 
--- make 'view' work
-x = torch.randn(1,1,3,4):cudaHalf()
-print(x)
-print(x:view(torch.LongStorage{1,1,4,3}))
-
 
 x = torch.randn(1,3,25,27)
 m = cudnn.SpatialConvolution(3,16,7,7,1,1,3,3)
 
-datatype = 'torch.CudaTensor'
---datatype = 'torch.CudaHalfTensor'
-x = x:type(datatype)
-m:clearDesc()
-m = m:type(datatype)
-y = m:forward(x):clone()
-y = y:cuda()
-print(y:sub(1,1, 1,3, 1,3, 1,3))
+function fwd(datatype)
+   x = x:type(datatype)
+   m:clearDesc()
+   m = m:type(datatype)
+   return m:forward(x):clone()
+end
 
+print('=========== single ===========')
+y1 = fwd('torch.CudaTensor')
+print(y1:sub(1,1, 1,3, 1,3, 1,3))
+
+print('============ half ============')
+y2 = fwd('torch.CudaHalfTensor'):cuda()
+print(y2:sub(1,1, 1,3, 1,3, 1,3))
+
+print('============ diff ============')
+yDiff = y2-y1
+print(yDiff:sub(1,1, 1,3, 1,3, 1,3))

--- a/test/test_fp16.lua
+++ b/test/test_fp16.lua
@@ -1,0 +1,21 @@
+require 'cudnn'
+require 'cunn'
+
+-- make 'view' work
+x = torch.randn(1,1,3,4):cudaHalf()
+print(x)
+print(x:view(torch.LongStorage{1,1,4,3}))
+
+
+x = torch.randn(1,3,25,27)
+m = cudnn.SpatialConvolution(3,16,7,7,1,1,3,3)
+
+datatype = 'torch.CudaTensor'
+--datatype = 'torch.CudaHalfTensor'
+x = x:type(datatype)
+m:clearDesc()
+m = m:type(datatype)
+y = m:forward(x):clone()
+y = y:cuda()
+print(y:sub(1,1, 1,3, 1,3, 1,3))
+


### PR DESCRIPTION
This PR includes fp16 support for the following modules: 
- SpatialConvolution
- all point-wise activations
- all 2d pooling operations
- all softmax
- SpatialCrossMapLRN
- SpatialDivisiveNormalization

Requires merge of torch/cutorch#394 first. 