### PR TITLE
[fix] errcheck is undeclared 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,7 @@ local function destroy(handle)
         -- streams go from 0 to maxStreamsPerDevice - 1
         for j=0,maxStreamsPerDevice - 1 do
             if handleStatus[i][j + 1] == 1 then -- if handle was created
-                errcheck('cudnnDestroy', handle[(((i-1)*maxStreamsPerDevice) + j)]);
+                cudnn.errcheck('cudnnDestroy', handle[(((i-1)*maxStreamsPerDevice) + j)]);
             end
         end
     end


### PR DESCRIPTION
Thanks for this amazing project. just to fix a tiny slip of the pen.

`errcheck` is not bound to correct function in `cudnn`
https://github.com/soumith/cudnn.torch/blob/master/init.lua#L25
