### PR TITLE
Exposed bias and weights for RNN

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -2,6 +2,13 @@ local RNN, parent = torch.class('cudnn.RNN', 'nn.Module')
 local ffi = require 'ffi'
 local errcheck = cudnn.errcheck
 
+RNN.linearLayers = {
+    CUDNN_LSTM = 8,
+    CUDNN_GRU = 6,
+    CUDNN_RNN_RELU = 2,
+    CUDNN_RNN_TANH = 2
+}
+
 function RNN:__init(inputSize, hiddenSize, numLayers, batchFirst)
    parent.__init(self)
 
@@ -502,6 +509,74 @@ function RNN:accGradParameters(input, gradOutput, scale)
                self.dw:data(),
                scaleTensor:data())
    end
+end
+
+local function numberOfLinearLayers(self)
+    return self.linearLayers[self.mode]
+end
+
+local function numberOfLayers(self)
+    if self.bidirectional == 'CUDNN_BIDIRECTIONAL' then
+        assert(self.numDirections == 2)
+        return 2 * self.numLayers
+    else
+        return self.numLayers
+    end
+end
+
+-- Function gets either the matrix or bias param x on cuDNN method given, at each layer and linear layerId.
+local function retrieveLinearParams(self, cuDNNMethod)
+    if not self.wDesc then
+        self:resetWeightDescriptor()
+    end
+    local linearParams = {}
+    local numberOfLinearLayers = numberOfLinearLayers(self)
+    local numLayers = numberOfLayers(self)
+    for layer = 0, numLayers - 1 do
+        local layerInfo = {}
+        for layerId = 0, numberOfLinearLayers - 1 do
+            local linLayerMatDesc = self:createFilterDescriptors(1)
+            local matrixPointer = ffi.new("float*[1]")
+            errcheck(cuDNNMethod,
+                cudnn.getHandle(),
+                self.rnnDesc[0],
+                layer,
+                self.xDescs[0],
+                self.wDesc[0],
+                self.weight:data(),
+                layerId,
+                linLayerMatDesc[0],
+                ffi.cast("void**", matrixPointer))
+
+            local dataType = 'CUDNN_DATA_FLOAT'
+            local format = 'CUDNN_TENSOR_NCHW'
+            local nbDims = torch.IntTensor(1)
+
+            local minDim = 3
+            local filterDimA = torch.ones(minDim):int()
+            errcheck('cudnnGetFilterNdDescriptor',
+                linLayerMatDesc[0],
+                minDim,
+                ffi.cast("cudnnDataType_t*", dataType),
+                ffi.cast("cudnnDataType_t*", format),
+                nbDims:data(),
+                filterDimA:data())
+
+            local offset = matrixPointer[0] - self.weight:data()
+            local params = torch.CudaTensor(self.weight:storage(), offset + 1, filterDimA:prod())
+            table.insert(layerInfo, params)
+        end
+        table.insert(linearParams, layerInfo)
+    end
+    return linearParams
+end
+
+function RNN:weights()
+    return retrieveLinearParams(self, 'cudnnGetRNNLinLayerMatrixParams')
+end
+
+function RNN:biases()
+    return retrieveLinearParams(self, 'cudnnGetRNNLinLayerBiasParams')
 end
 
 function RNN:clearDesc()


### PR DESCRIPTION
Hey I've added back the functions to expose the weights and the biases for the RNN modules. Currently they are given in a Lua table to keep things split, but would it be better to have them as one large tensor? Open to feedback!

It may also be worthwhile to add some documentation to explain how to interpret the outputs, but not sure where to add this. Thanks to @willfrey for his help :)