### PR TITLE
Un-untranspose RNN outputs after doing grad updates

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -437,6 +437,7 @@ function RNN:updateGradInput(input, gradOutput)
             self.reserve:data(), self.reserve:size(1) * 4) -- sizeof(float)
     if (self.batchFirst) then
         self.gradInput = self.gradInput:transpose(1, 2)
+        self.output = self.output:transpose(1, 2)
     end
    return self.gradInput
 end
@@ -445,6 +446,7 @@ function RNN:accGradParameters(input, gradOutput, scale)
     if (self.batchFirst) then
         input = input:transpose(1, 2)
         gradOutput = gradOutput:transpose(1, 2)
+        self.output = self.output:transpose(1, 2)
     end
    scale = scale or 1
    if scale == 0 then return end
@@ -502,6 +504,11 @@ function RNN:accGradParameters(input, gradOutput, scale)
                self.dw:data(),
                scaleTensor:data())
    end
+
+    if (self.batchFirst) then
+        gradOutput = gradOutput:transpose(1, 2)
+        self.output = self.output:transpose(1, 2)
+    end
 end
 
 function RNN:clearDesc()


### PR DESCRIPTION
When running an RNN with `batchFirst = true`, the shape of `input` for downstream modules mysteriously changes between `updateGradInput` and `accGradParams`. That's because the output tensors of the RNN are un-transposed (to non-batch first) but not un-un-transposed (back to batch first). This PR attempts to fix that by inverting the tranpositions done at the beginning of `*Grad*`.