### PR TITLE
Added tests to rocks install

### DIFF
--- a/cudnn-scm-1.rockspec
+++ b/cudnn-scm-1.rockspec
@@ -26,5 +26,9 @@ build = {
    build_command = [[
 cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
 ]],
-   install_command = "cd build && $(MAKE) install"
+   install_command = "cd build && $(MAKE) install",
+   copy_directories = {
+      "test"
+   }
+
 }


### PR DESCRIPTION
Installing tests into shared dir as some other modules do.
Having tests synchronized with the installed version helps a lot with QA.
