### PR TITLE
CUDNN Find refactoring, take 2

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -63,43 +63,29 @@ function RNN:reset(stdv)
    self.gradWeight:resizeAs(self.weight):zero()
 end
 
-function RNN:createDescriptors(count, descs_type, create_func, destroy_func)
-   local ds = ffi.new(descs_type, count)
-   for i = 0, count - 1 do
-      errcheck(create_func, ds + i)
-   end
-   local function destroyDescriptors(ds)
-      for i = 0, count - 1 do
-         errcheck(destroy_func, ds[i])
-      end
-   end
-   ffi.gc(ds, destroyDescriptors)
-   return ds
-end
-
 function RNN:createDropoutDescriptors(count)
-   return self:createDescriptors(count,
+   return cudnn.createDescriptors(count,
                             'cudnnDropoutDescriptor_t[?]',
                             'cudnnCreateDropoutDescriptor',
                             'cudnnDestroyDropoutDescriptor')
 end
 
 function RNN:createFilterDescriptors(count)
-   return self:createDescriptors(count,
+   return cudnn.createDescriptors(count,
                             'cudnnFilterDescriptor_t[?]',
                             'cudnnCreateFilterDescriptor',
                             'cudnnDestroyFilterDescriptor')
 end
 
 function RNN:createRNNDescriptors(count)
-   return self:createDescriptors(count,
+   return cudnn.createDescriptors(count,
                             'cudnnRNNDescriptor_t[?]',
                             'cudnnCreateRNNDescriptor',
                             'cudnnDestroyRNNDescriptor')
 end
 
 function RNN:createTensorDescriptors(count)
-   return self:createDescriptors(count,
+   return cudnn.createDescriptors(count,
                             'cudnnTensorDescriptor_t[?]',
                             'cudnnCreateTensorDescriptor',
                             'cudnnDestroyTensorDescriptor')
@@ -383,7 +369,7 @@ function RNN:updateOutput(input)
 	if self.cellOutput then
 	   self.cellInput = self.cellOutput:clone()
         end
-   end    
+   end
    if (self.batchFirst) then
       self.output = self.output:transpose(1, 2)
    end

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -1,12 +1,8 @@
 local SpatialConvolution, parent =
     torch.class('cudnn.SpatialConvolution', 'nn.SpatialConvolution')
 local ffi = require 'ffi'
-local errcheck = cudnn.errcheck
-
-local autotunerCache = {}
-autotunerCache[1] = {} -- forward
-autotunerCache[2] = {} -- backwardFilter
-autotunerCache[3] = {} -- backwardData
+local algo = require 'cudnn.algo'
+local errcheck = algo.errcheck
 
 function SpatialConvolution:__init(nInputPlane, nOutputPlane,
                             kW, kH, dW, dH, padW, padH, groups)
@@ -28,37 +24,37 @@ function SpatialConvolution:__init(nInputPlane, nOutputPlane,
     self.reset = nil
 end
 
--- if you change the configuration of the module manually, call this
-function SpatialConvolution:resetWeightDescriptors()
+function SpatialConvolution:createWeightDescriptors()
     assert(cudnn.typemap[torch.typename(self.weight)], 'Only Cuda supported duh!')
     assert(cudnn.typemap[torch.typename(self.bias)] or not self.bias, 'Only Cuda supported duh!')
-    -- for compatibility
-    self.groups = self.groups or 1
-    -- create filterDescriptor for weight
-    self.weightDesc = ffi.new('struct cudnnFilterStruct*[1]')
-    errcheck('cudnnCreateFilterDescriptor', self.weightDesc)
-    local desc = torch.IntTensor({self.nOutputPlane/self.groups,
-                              self.nInputPlane/self.groups,
-                              self.kH, self.kW})
-    errcheck('cudnnSetFilterNdDescriptor', self.weightDesc[0],
-             cudnn.typemap[torch.typename(self.weight)], 'CUDNN_TENSOR_NCHW', 4,
-             desc:data());
-    local function destroyWDesc(d)
-        errcheck('cudnnDestroyFilterDescriptor', d[0]);
-    end
-    ffi.gc(self.weightDesc, destroyWDesc)
-
     -- create descriptor for bias
     if self.bias then
         self.biasDesc = cudnn.toDescriptor(self.bias:view(1, self.nOutputPlane,1,1))
     end
+    -- create filterDescriptor for weight
+    return cudnn.createDescriptors(1, 'struct cudnnFilterStruct*[?]',
+                                   'cudnnCreateFilterDescriptor', 'cudnnDestroyFilterDescriptor')
+end
+
+-- if you change the configuration of the module manually, call this
+function SpatialConvolution:resetWeightDescriptors(desc)
+    -- for compatibility
+    self.groups = self.groups or 1
+    self.weightDesc = SpatialConvolution.createWeightDescriptors(self)
+    desc = desc or torch.IntTensor({self.nOutputPlane/self.groups,
+                                    self.nInputPlane/self.groups,
+                                    self.kH, self.kW})
+
+    errcheck(self,'cudnnSetFilterNdDescriptor', self.weightDesc[0],
+             cudnn.typemap[torch.typename(self.weight)], 'CUDNN_TENSOR_NCHW', desc:nElement(),
+             desc:data());
+    return self
 end
 
 function SpatialConvolution:fastest(mode)
     if mode == nil then mode = true end
     self.fastest_mode = mode
-    self.iSize = self.iSize or torch.LongStorage(4)
-    self.iSize:fill(0)
+    self.iDesc = nil
     return self
 end
 
@@ -72,8 +68,7 @@ function SpatialConvolution:setMode(fmode, bdmode, bwmode)
     if bwmode ~= nil then
         self.bwmode = bwmode
     end
-    self.iSize = self.iSize or torch.LongStorage(4)
-    self.iSize:fill(0)
+    self.iDesc = nil
     return self
 end
 
@@ -90,243 +85,67 @@ function SpatialConvolution:noBias()
    return self
 end
 
-function SpatialConvolution:createIODescriptors(input)
-    local batch = true
-    if input:dim() == 3 then
-        input = input:view(1, input:size(1), input:size(2), input:size(3))
-        batch = false
+
+function SpatialConvolution:checkInputChanged(input)
+    assert(input:isContiguous())
+    if not self.iSize or self.iSize:size() ~= input:dim() then
+       self.iSize = torch.LongStorage(input:dim()):fill(0)
     end
-    assert(input:dim() == 4 and input:isContiguous());
-    self.iSize = self.iSize or torch.LongStorage(4):fill(0)
-    if not self.iDesc or not self.oDesc or
-        input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-    or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
-        self.iSize = input:size()
+    self.groups = self.groups or 1
+    if not self.weightDesc then self:resetWeightDescriptors() end
+    if not self.iDesc or not self.oDesc or input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
+    or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] or (input:dim()==5 and input:size(5) ~= self.iSize[5]) then
+       self.iSize = input:size()
 
-        assert(self.nInputPlane == input:size(2), 'input has to contain: '
-                   .. self.nInputPlane
-                   .. ' feature maps, but received input of size: '
-                   .. input:size(1) .. ' x ' .. input:size(2) ..
-                   ' x ' .. input:size(3) .. ' x ' .. input:size(4))
+       assert(self.nInputPlane == input:size(2), 'input has to contain: '
+                 .. self.nInputPlane
+                 .. ' feature maps, but received input of size: '
+                 .. input:size(1) .. ' x ' .. input:size(2) ..
+                 ' x ' .. input:size(3) .. ' x ' .. input:size(4))
+       return true
+    end
+    return false
+end
 
+function SpatialConvolution:createIODescriptors(input)
+   local batch = true
+   if input:dim() == 3 then
+      input = input:view(1, input:size(1), input:size(2), input:size(3))
+      batch = false
+   end
+   if SpatialConvolution.checkInputChanged(self, input) then
         -- create input descriptor
         local input_slice = input:narrow(2,1,self.nInputPlane/self.groups)
         self.iDesc = cudnn.toDescriptor(input_slice)
-
         -- create conv descriptor
-        self.convDesc = ffi.new('struct cudnnConvolutionStruct*[1]')
-        errcheck('cudnnCreateConvolutionDescriptor', self.convDesc)
+        self.convDesc = cudnn.createDescriptors(1, 'struct cudnnConvolutionStruct*[?]',
+                                                'cudnnCreateConvolutionDescriptor', 'cudnnDestroyConvolutionDescriptor')
         self.padH, self.padW = self.padH or 0, self.padW or 0
         local pad = torch.IntTensor({self.padH, self.padW})
         local stride = torch.IntTensor({self.dH, self.dW})
         local upscale = torch.IntTensor({1,1})
-        errcheck('cudnnSetConvolutionNdDescriptor', self.convDesc[0],
+        errcheck(self,'cudnnSetConvolutionNdDescriptor', self.convDesc[0],
                  2, pad:data(),
                  stride:data(), upscale:data(), 'CUDNN_CROSS_CORRELATION',
                  cudnn.configmap(torch.type(self.weight)));
-        local function destroyConvDesc(d)
-            errcheck('cudnnDestroyConvolutionDescriptor', d[0]);
-        end
-        ffi.gc(self.convDesc, destroyConvDesc)
+
 
         -- get output shape, resize output
         local oSize = torch.IntTensor(4)
-        local oSizeD = oSize:data()
-        errcheck('cudnnGetConvolutionNdForwardOutputDim',
+        errcheck(self,'cudnnGetConvolutionNdForwardOutputDim',
                  self.convDesc[0], self.iDesc[0],
-                 self.weightDesc[0], 4, oSizeD)
+                 self.weightDesc[0], 4, oSize:data())
         oSize[2] = oSize[2] * self.groups
         self.output:resize(oSize:long():storage())
+        self.oSize = self.output:size()
 
-        -- create descriptor for output
         local output_slice = self.output:narrow(2,1,self.nOutputPlane/self.groups)
+        -- create descriptor for output
         self.oDesc = cudnn.toDescriptor(output_slice)
         self.oDescForBias = cudnn.toDescriptor(self.output)
 
-        -----------------------------------------------------------------------
-        local function shape(x)
-            local sz = x:size()
-            local str = ''
-            for i=1,sz:size() do
-                str = str .. sz[i] .. 'x'
-            end
-            if #str > 0 then
-                str = str:sub(1, #str-1)
-            end
-            return str
-        end
-        local autotunerHash = shape(self.weight) .. ';'
-            .. shape(input_slice) .. ';'
-            .. shape(output_slice)
+        algo.prepareHash(self, input_slice, output_slice)
 
-        local maxBufSize = 0
-
-        -- create forwardAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionFwdAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT'
-        local algWorkspaceLimit = self.workspace_limit
-           or (self.nInputPlane * self.kH * self.kW * cudnn.sizeof(self.weight))
-
-        if self.fastest_mode or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST'
-        end
-
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[1][autotunerHash] then
-                algType[0] = autotunerCache[1][autotunerHash]
-                if cudnn.verbose then
-                   print('Autotuning SC FW: using cached algo = ', algType[0], ' for: ', autotunerHash)
-                end
-            else
-                local perfResults = ffi.new("cudnnConvolutionFwdAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionForwardAlgorithm',
-                         cudnn.getHandle(),
-                         self.iDesc[0], self.weightDesc[0],
-                         self.convDesc[0], self.oDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[1][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "\nAutotuning SC     Forward: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input_slice),
-                              shape(output_slice)))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionForwardAlgorithm',
-                     cudnn.getHandle(),
-                     self.iDesc[0], self.weightDesc[0],
-                     self.convDesc[0], self.oDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.fmode or algType[0]
-        self.fwdAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionForwardWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.iDesc[0], self.weightDesc[0],
-                 self.convDesc[0], self.oDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        -- create backwardFilterAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionBwdFilterAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE'
-        local algWorkspaceLimit = self.workspace_limit
-           or (self.nInputPlane * self.kH * self.kW * cudnn.sizeof(self.weight))
-        if self.fastest_mode  or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST'
-        end
-
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[2][autotunerHash] then
-                algType[0] = autotunerCache[2][autotunerHash]
-                if cudnn.verbose then
-                   print('Autotuning SC BW: using cached algo = ', algType[0], ' for: ', autotunerHash)
-                end
-            else
-                local perfResults = ffi.new("cudnnConvolutionBwdFilterAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionBackwardFilterAlgorithm',
-                         cudnn.getHandle(),
-                         self.iDesc[0], self.oDesc[0],
-                         self.convDesc[0], self.weightDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[2][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "Autotuning backwardFilter: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input_slice),
-                              shape(output_slice)))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionBackwardFilterAlgorithm',
-                     cudnn.getHandle(),
-                     self.iDesc[0], self.oDesc[0],
-                     self.convDesc[0], self.weightDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.bwmode or algType[0]
-        self.bwdFilterAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionBackwardFilterWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.iDesc[0], self.oDesc[0],
-                 self.convDesc[0], self.weightDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        -- create backwardDataAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionBwdDataAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE'
-        local algWorkspaceLimit = self.workspace_limit
-           or (self.nInputPlane * self.kH * self.kW * cudnn.sizeof(self.weight))
-        if self.fastest_mode or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST'
-        end
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[3][autotunerHash] then
-                algType[0] = autotunerCache[3][autotunerHash]
-                if cudnn.verbose then
-                   print('Autotuning SC BWD: using cached algo = ', algType[0], ' for: ', autotunerHash)
-                end
-            else
-                local perfResults = ffi.new("cudnnConvolutionBwdDataAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionBackwardDataAlgorithm',
-                         cudnn.getHandle(),
-                         self.weightDesc[0], self.oDesc[0],
-                         self.convDesc[0], self.iDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[3][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "Autotuning   backwardData: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s\n",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input_slice),
-                              shape(output_slice)))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionBackwardDataAlgorithm',
-                     cudnn.getHandle(),
-                     self.weightDesc[0], self.oDesc[0],
-                     self.convDesc[0], self.iDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.bdmode or algType[0]
-        self.bwdDataAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionBackwardDataWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.weightDesc[0], self.oDesc[0],
-                 self.convDesc[0], self.iDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        self.extraBuffer = self.extraBuffer or cudnn.getSharedWorkspace()
-        self.extraBuffer = self.extraBuffer:cuda() -- always force float
-        self.extraBufferSizeInBytes =
-           self.extraBuffer:nElement() * 4 -- extraBuffer is always float
-        if maxBufSize > self.extraBufferSizeInBytes then
-           self.extraBuffer:resize(math.ceil(maxBufSize / 4))
-           self.extraBufferSizeInBytes = maxBufSize
-        end
-
-        -----------------------------------------------------------------------
         -- create offsets for groups
         local iH, iW = input:size(3), input:size(4)
         local kH, kW = self.kH, self.kW
@@ -340,11 +159,10 @@ function SpatialConvolution:createIODescriptors(input)
                                            self.output:size(3),
                                            self.output:size(4))
         end
-    end
+
+   end
+   return self
 end
-
-
-
 
 local function makeContiguous(self, input, gradOutput)
    if not input:isContiguous() then
@@ -361,24 +179,25 @@ local function makeContiguous(self, input, gradOutput)
 end
 
 function SpatialConvolution:updateOutput(input)
-    if not self.weightDesc then self:resetWeightDescriptors() end
     input = makeContiguous(self, input)
     self:createIODescriptors(input)
-
+    if not self.fwdAlgType then
+       algo.setupForwardAlgorithm(self)
+    end
     for g = 0, self.groups - 1 do
-        errcheck('cudnnConvolutionForward', cudnn.getHandle(),
+        errcheck(self,'cudnnConvolutionForward', cudnn.getHandle(),
                  cudnn.scalar(input, 1),
                  self.iDesc[0], input:data() + g*self.input_offset,
                  self.weightDesc[0], self.weight:data() + g*self.weight_offset,
-                 self.convDesc[0], self.fwdAlgType[0],
-                 self.extraBuffer:data(), self.extraBufferSizeInBytes,
+                 self.convDesc[0], self.fwdAlgType,
+                 self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
                  cudnn.scalar(input, 0),
                  self.oDesc[0], self.output:data() + g*self.output_offset);
     end
 
     -- add bias
     if self.bias then
-        errcheck('cudnnAddTensor', cudnn.getHandle(),
+        errcheck(self,'cudnnAddTensor', cudnn.getHandle(),
                  cudnn.scalar(input, 1), self.biasDesc[0], self.bias:data(),
                  cudnn.scalar(input, 1), self.oDescForBias[0], self.output:data())
     end
@@ -389,22 +208,26 @@ end
 function SpatialConvolution:updateGradInput(input, gradOutput)
     if not self.gradInput then return end
     self.gradInput:resizeAs(input)
-
+    assert(gradOutput:dim() == input:dim()-1 or gradOutput:dim() == input:dim()
+              or (gradOutput:dim()==5 and input:dim()==4), 'Wrong gradOutput dimensions');
     input, gradOutput = makeContiguous(self, input, gradOutput)
-    assert(gradOutput:dim() == 3 or gradOutput:dim() == 4, 'gradOutput has to be 3D or 4D');
-    if not self.weightDesc then self:resetWeightDescriptors() end
     self:createIODescriptors(input)
 
+
+    if not self.bwdDataAlgType then
+       algo.setupBackwardDataAlgorithm(self)
+    end
+
     for g = 0,self.groups - 1 do
-        errcheck('cudnnConvolutionBackwardData', cudnn.getHandle(),
-                 cudnn.scalar(input, 1),
-                 self.weightDesc[0], self.weight:data() + g*self.weight_offset,
-                 self.oDesc[0], gradOutput:data() + g*self.output_offset,
-                 self.convDesc[0],
-                 self.bwdDataAlgType[0],
-                 self.extraBuffer:data(), self.extraBufferSizeInBytes,
-                 cudnn.scalar(input, 0),
-                 self.iDesc[0], self.gradInput:data() + g*self.input_offset);
+        local success = errcheck(self,'cudnnConvolutionBackwardData', cudnn.getHandle(),
+                                 cudnn.scalar(input, 1),
+                                 self.weightDesc[0], self.weight:data() + g*self.weight_offset,
+                                 self.oDesc[0], gradOutput:data() + g*self.output_offset,
+                                 self.convDesc[0],
+                                 self.bwdDataAlgType,
+                                 self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
+                                 cudnn.scalar(input, 0),
+                                 self.iDesc[0], self.gradInput:data() + g*self.input_offset)
     end
     return self.gradInput
 end
@@ -419,13 +242,13 @@ function SpatialConvolution:accGradParameters(input, gradOutput, scale)
 
     input, gradOutput = makeContiguous(self, input, gradOutput)
 
-    assert(gradOutput:dim() == 3 or gradOutput:dim() == 4, 'gradOutput has to be 3D or 4D');
-    if not self.weightDesc then self:resetWeightDescriptors() end
-    self:createIODescriptors(input)
+    if not self.bwdFilterAlgType then
+       algo.setupBackwardFilterAlgorithm(self)
+    end
 
     -- gradBias
     if self.bias then
-        errcheck('cudnnConvolutionBackwardBias', cudnn.getHandle(),
+        errcheck(self,'cudnnConvolutionBackwardBias', cudnn.getHandle(),
                  self.scaleT:data(),
                  self.oDescForBias[0], gradOutput:data(),
                  cudnn.scalar(input, 1),
@@ -434,16 +257,17 @@ function SpatialConvolution:accGradParameters(input, gradOutput, scale)
 
     for g = 0, self.groups - 1 do
         -- gradWeight
-        errcheck('cudnnConvolutionBackwardFilter', cudnn.getHandle(),
+        errcheck(self,'cudnnConvolutionBackwardFilter', cudnn.getHandle(),
                  self.scaleT:data(),
                  self.iDesc[0], input:data() + g*self.input_offset,
                  self.oDesc[0], gradOutput:data() + g*self.output_offset,
                  self.convDesc[0],
-                 self.bwdFilterAlgType[0],
-                 self.extraBuffer:data(), self.extraBufferSizeInBytes,
+                 self.bwdFilterAlgType,
+                 self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
                  cudnn.scalar(input, 1),
                  self.weightDesc[0], self.gradWeight:data() + g*self.weight_offset);
     end
+    return self.gradOutput
 end
 
 function SpatialConvolution:clearDesc()
@@ -453,13 +277,14 @@ function SpatialConvolution:clearDesc()
     self.iDesc = nil
     self.oDesc = nil
     self.oDescForBias = nil
+    self.oSize = nil
     self.algType = nil
     self.fwdAlgType = nil
     self.bwdDataAlgType = nil
     self.bwdFilterAlgType = nil
     self.extraBuffer = nil
-    self.extraBufferSizeInBytes = nil
     self.scaleT = nil
+    return self
 end
 
 function SpatialConvolution:write(f)

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -219,15 +219,15 @@ function SpatialConvolution:updateGradInput(input, gradOutput)
     end
 
     for g = 0,self.groups - 1 do
-        local success = errcheck(self,'cudnnConvolutionBackwardData', cudnn.getHandle(),
-                                 cudnn.scalar(input, 1),
-                                 self.weightDesc[0], self.weight:data() + g*self.weight_offset,
-                                 self.oDesc[0], gradOutput:data() + g*self.output_offset,
-                                 self.convDesc[0],
-                                 self.bwdDataAlgType,
-                                 self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
-                                 cudnn.scalar(input, 0),
-                                 self.iDesc[0], self.gradInput:data() + g*self.input_offset)
+        errcheck(self,'cudnnConvolutionBackwardData', cudnn.getHandle(),
+                 cudnn.scalar(input, 1),
+                 self.weightDesc[0], self.weight:data() + g*self.weight_offset,
+                 self.oDesc[0], gradOutput:data() + g*self.output_offset,
+                 self.convDesc[0],
+                 self.bwdDataAlgType,
+                 self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
+                 cudnn.scalar(input, 0),
+                 self.iDesc[0], self.gradInput:data() + g*self.input_offset)
     end
     return self.gradInput
 end

--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -86,8 +86,8 @@ end
 function SpatialFullConvolution:updateOutput(input)
     self:createIODescriptors(input)
     if not self.bwdDataAlgType then
-       algo.setupBackwardDataAlgorithm(self, {self.weightDesc[0], self.weight:data(), self.iDesc[0],self.input_slice:data(),
-                                              self.convDesc[0], self.oDesc[0], self.output_slice:data()})
+       algo.setupBackwardDataAlgorithm(self, {self.weightDesc[0], self.weight, self.iDesc[0],self.input_slice,
+                                              self.convDesc[0], self.oDesc[0], self.output_slice})
     end
 
     -- Because SpatialFullConvolution is performing the adjoint of the forward
@@ -119,8 +119,8 @@ function SpatialFullConvolution:updateGradInput(input, gradOutput)
     assert(gradOutput:isContiguous(), 'gradOutput has to be contiguous')
     self:createIODescriptors(input)
     if not self.fwdDataAlgType then
-       algo.setupForwardAlgorithm(self, {self.oDesc[0], self.output_slice:data(), self.weightDesc[0], self.weight:data(),
-                                         self.convDesc[0], self.iDesc[0], self.input_slice:data() })
+       algo.setupForwardAlgorithm(self, {self.oDesc[0], self.output_slice, self.weightDesc[0], self.weight,
+                                         self.convDesc[0], self.iDesc[0], self.input_slice})
     end
 
     errcheck(self,'cudnnConvolutionForward', cudnn.getHandle(),
@@ -148,8 +148,8 @@ function SpatialFullConvolution:accGradParameters(input, gradOutput, scale)
     assert(gradOutput:isContiguous(), 'gradOutput has to be contiguous')
     self:createIODescriptors(input)
     if not self.bwdFilterAlgType then
-       algo.setupBackwardFilterAlgorithm(self, {self.oDesc[0], self.output_slice:data(), self.iDesc[0], self.input_slice:data(),
-                                                self.convDesc[0], self.weightDesc[0], self.weight:data()})
+       algo.setupBackwardFilterAlgorithm(self, {self.oDesc[0], self.output_slice, self.iDesc[0], self.input_slice,
+                                                self.convDesc[0], self.weightDesc[0], self.weight})
     end
 
     -- gradBias

--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -1,71 +1,31 @@
 local SpatialFullConvolution, parent =
     torch.class('cudnn.SpatialFullConvolution', 'nn.SpatialFullConvolution')
 local ffi = require 'ffi'
-local errcheck = cudnn.errcheck
+local algo = require 'cudnn.algo'
+local errcheck = algo.errcheck
 
-local autotunerCache = {}
-autotunerCache[1] = {} -- forward
-autotunerCache[2] = {} -- backwardFilter
-autotunerCache[3] = {} -- backwardData
+local Convolution = cudnn.SpatialConvolution
 
--- if you change the configuration of the module manually, call this
 function SpatialFullConvolution:resetWeightDescriptors()
-    assert(cudnn.typemap[torch.typename(self.weight)], 'Only Cuda supported duh!')
-    assert(cudnn.typemap[torch.typename(self.bias)] or not self.bias, 'Only Cuda supported duh!')
-    -- create filterDescriptor for weight
-    self.weightDesc = ffi.new('struct cudnnFilterStruct*[1]')
-    errcheck('cudnnCreateFilterDescriptor', self.weightDesc)
-    local desc = torch.IntTensor({self.nInputPlane,
-                                  self.nOutputPlane,
-                                  self.kH, self.kW})
-    errcheck('cudnnSetFilterNdDescriptor', self.weightDesc[0],
-             cudnn.typemap[torch.typename(self.weight)], 'CUDNN_TENSOR_NCHW', 4,
-             desc:data());
-    local function destroyWDesc(d)
-        errcheck('cudnnDestroyFilterDescriptor', d[0]);
-    end
-    ffi.gc(self.weightDesc, destroyWDesc)
-
-    -- create descriptor for bias
-    if self.bias then
-        self.biasDesc = cudnn.toDescriptor(self.bias:view(1, self.nOutputPlane,1,1))
-    end
+   return Convolution.resetWeightDescriptors(self, torch.IntTensor({self.nInputPlane,
+                                                                    self.nOutputPlane,
+                                                                    self.kH, self.kW}))
 end
 
 function SpatialFullConvolution:fastest(mode)
-    if mode == nil then mode = true end
-    self.fastest_mode = mode
-    self.iSize = self.iSize or torch.LongStorage(4)
-    self.iSize:fill(0)
-    return self
+   return Convolution.fastest(self, mode)
 end
 
 function SpatialFullConvolution:setMode(fmode, bdmode, bwmode)
-    if fmode ~= nil then
-        self.fmode = fmode
-    end
-    if bdmode ~= nil then
-        self.bdmode = bdmode
-    end
-    if bwmode ~= nil then
-        self.bwmode = bwmode
-    end
-    self.iSize = self.iSize or torch.LongStorage(4)
-    self.iSize:fill(0)
-    return self
+   return Convolution.setMode(self, fmode, bdmode, bwmode)
 end
 
 function SpatialFullConvolution:resetMode()
-    self.fmode = nil
-    self.bdmode = nil
-    self.bwmode = nil
-    return self
+   return Convolution.resetMode(self)
 end
 
 function SpatialFullConvolution:noBias()
-   self.bias = nil
-   self.gradBias = nil
-   return self
+   return Convolution.noBias(self)
 end
 
 function SpatialFullConvolution:createIODescriptors(input)
@@ -76,35 +36,22 @@ function SpatialFullConvolution:createIODescriptors(input)
     end
     assert(input:dim() == 4 and input:isContiguous());
     self.iSize = self.iSize or torch.LongStorage(4):fill(0)
-    if not self.iDesc or not self.oDesc or
-        input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-    or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
-        self.iSize = input:size()
 
-        assert(self.nInputPlane == input:size(2), 'input has to contain: '
-                   .. self.nInputPlane
-                   .. ' feature maps, but received input of size: '
-                   .. input:size(1) .. ' x ' .. input:size(2) ..
-                   ' x ' .. input:size(3) .. ' x ' .. input:size(4))
-
+    if Convolution.checkInputChanged(self, input) then
         -- create input descriptor
-        local input_slice = {{},{1,self.nInputPlane},{},{}}
-        self.iDesc = cudnn.toDescriptor(input[input_slice])
+        local input_slice = input[{{},{1,self.nInputPlane},{},{}}]
+        self.iDesc = cudnn.toDescriptor(input_slice)
 
         -- create conv descriptor
-        self.convDesc = ffi.new('struct cudnnConvolutionStruct*[1]')
-        errcheck('cudnnCreateConvolutionDescriptor', self.convDesc)
+        self.convDesc = cudnn.createDescriptors(1, 'struct cudnnConvolutionStruct*[?]',
+                                                'cudnnCreateConvolutionDescriptor', 'cudnnDestroyConvolutionDescriptor')
         local pad = torch.IntTensor({self.padH, self.padW})
         local stride = torch.IntTensor({self.dH, self.dW})
         local upscale = torch.IntTensor({1,1})
-        errcheck('cudnnSetConvolutionNdDescriptor', self.convDesc[0],
+        errcheck(self,'cudnnSetConvolutionNdDescriptor', self.convDesc[0],
                  2, pad:data(),
                  stride:data(), upscale:data(), 'CUDNN_CROSS_CORRELATION',
                  cudnn.configmap(torch.type(self.weight)));
-        local function destroyConvDesc(d)
-            errcheck('cudnnDestroyConvolutionDescriptor', d[0]);
-        end
-        ffi.gc(self.convDesc, destroyConvDesc)
 
         -- get output shape, resize output
         local iwidth = input:size(4)
@@ -115,184 +62,15 @@ function SpatialFullConvolution:createIODescriptors(input)
         self.output:resize(oSize:long():storage())
 
         -- create descriptor for output
-        local output_slice = {{},{1,self.nOutputPlane},{},{}}
-        self.oDesc = cudnn.toDescriptor(self.output[output_slice])
+        local output_slice = self.output[{{},{1,self.nOutputPlane},{},{}}]
+        self.oDesc = cudnn.toDescriptor(output_slice)
         self.oDescForBias = cudnn.toDescriptor(self.output)
 
-        -----------------------------------------------------------------------
-        local function shape(x)
-            local sz = x:size()
-            local str = ''
-            for i=1,sz:size() do
-                str = str .. sz[i] .. 'x'
-            end
-            if #str > 0 then
-                str = str:sub(1, #str-1)
-            end
-            return str
-        end
-        local autotunerHash = shape(self.weight) .. ';'
-            .. shape(input[input_slice]) .. ';'
-            .. shape(self.output[output_slice])
+        self.input_offset = 0
+        self.output_offset = 0
+        self.weight_offset = 0
 
-        local maxBufSize = 0
-
-        -- create forwardAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionFwdAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT'
-        local algWorkspaceLimit = self.workspace_limit
-            or (self.nOutputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-
-        if self.fastest_mode or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST'
-        end
-
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[1][autotunerHash] then
-                algType[0] = autotunerCache[1][autotunerHash]
-                if cudnn.verbose then
-                   print('Autotuning SFC: using cached algo = ', algType[0], ' for: ', autotunerHash)
-                end
-            else
-                local perfResults = ffi.new("cudnnConvolutionFwdAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionForwardAlgorithm',
-                         cudnn.getHandle(),
-                         self.oDesc[0], self.weightDesc[0],
-                         self.convDesc[0], self.iDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[1][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "Autotuning        Forward: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input[input_slice]),
-                              shape(self.output[output_slice])))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionForwardAlgorithm',
-                     cudnn.getHandle(),
-                     self.oDesc[0], self.weightDesc[0],
-                     self.convDesc[0], self.iDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.fmode or algType[0]
-        self.fwdAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionForwardWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.oDesc[0], self.weightDesc[0],
-                 self.convDesc[0], self.iDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        -- create backwardFilterAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionBwdFilterAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE'
-        local algWorkspaceLimit = self.workspace_limit
-            or (self.nOutputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-        if self.fastest_mode  or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST'
-        end
-
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[2][autotunerHash] then
-                algType[0] = autotunerCache[2][autotunerHash]
-            else
-                local perfResults = ffi.new("cudnnConvolutionBwdFilterAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionBackwardFilterAlgorithm',
-                         cudnn.getHandle(),
-                         self.oDesc[0], self.iDesc[0],
-                         self.convDesc[0], self.weightDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[2][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "Autotuning backwardFilter: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input[input_slice]),
-                              shape(self.output[output_slice])))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionBackwardFilterAlgorithm',
-                     cudnn.getHandle(),
-                     self.oDesc[0], self.iDesc[0],
-                     self.convDesc[0], self.weightDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.bwmode or algType[0]
-        self.bwdFilterAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionBackwardFilterWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.oDesc[0], self.iDesc[0],
-                 self.convDesc[0], self.weightDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        -- create backwardDataAlgorithm descriptors
-        local algType = ffi.new("cudnnConvolutionBwdDataAlgo_t[?]", 1)
-        local algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE'
-        local algWorkspaceLimit = self.workspace_limit
-            or (self.nOutputPlane * self.kH * self.kW * 4) -- 4 = sizeof int/float.
-        if self.fastest_mode or cudnn.fastest == true then
-            algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST'
-        end
-        if cudnn.benchmark then -- the manual auto-tuner is run
-            if autotunerCache[3][autotunerHash] then
-                algType[0] = autotunerCache[3][autotunerHash]
-            else
-                local perfResults = ffi.new("cudnnConvolutionBwdDataAlgoPerf_t[?]", 1)
-                local intt = torch.IntTensor(1);
-                errcheck('cudnnFindConvolutionBackwardDataAlgorithm',
-                         cudnn.getHandle(),
-                         self.weightDesc[0], self.iDesc[0],
-                         self.convDesc[0], self.oDesc[0],
-                         1, intt:data(), perfResults)
-                algType[0] = perfResults[0].algo
-                autotunerCache[3][autotunerHash] = perfResults[0].algo
-                if cudnn.verbose then
-                    print(string.format(
-                              "Autotuning   backwardData: Time: %3.5f Memory: %8d Algorithm: %d"
-                                  .. " Weight: %15s Input: %15s Output: %15s\n",
-                              perfResults[0].time, tonumber(perfResults[0].memory),
-                              tonumber(perfResults[0].algo),
-                              shape(self.weight), shape(input[input_slice]),
-                              shape(self.output[output_slice])))
-                end
-            end
-        else
-            errcheck('cudnnGetConvolutionBackwardDataAlgorithm',
-                     cudnn.getHandle(),
-                     self.weightDesc[0], self.iDesc[0],
-                     self.convDesc[0], self.oDesc[0],
-                     algSearchMode, algWorkspaceLimit, algType)
-        end
-        algType[0] = self.bdmode or algType[0]
-        self.bwdDataAlgType = algType
-        local bufSize = torch.LongTensor(1)
-        errcheck('cudnnGetConvolutionBackwardDataWorkspaceSize',
-                 cudnn.getHandle(),
-                 self.weightDesc[0], self.iDesc[0],
-                 self.convDesc[0], self.oDesc[0],
-                 algType[0], bufSize:data())
-        maxBufSize = math.max(maxBufSize, bufSize[1])
-
-        self.extraBuffer = self.extraBuffer or cudnn.getSharedWorkspace()
-        self.extraBufferSizeInBytes = self.extraBuffer:nElement() * 4 -- float
-        if maxBufSize > self.extraBufferSizeInBytes then
-            self.extraBuffer:resize(math.ceil(maxBufSize/4))
-            self.extraBufferSizeInBytes = maxBufSize
-        end
+        algo.prepareHash(self, input_slice, output_slice)
 
         if not batch then
             self.output = self.output:view(self.output:size(2),
@@ -306,23 +84,26 @@ end
 
 
 function SpatialFullConvolution:updateOutput(input)
-    if not self.weightDesc then self:resetWeightDescriptors() end
     self:createIODescriptors(input)
+    if not self.bwdDataAlgType then
+       algo.setupBackwardDataAlgorithm(self, {self.weightDesc[0], self.weight:data(), self.iDesc[0],self.input_slice:data(),
+                                              self.convDesc[0], self.oDesc[0], self.output_slice:data()})
+    end
 
     -- Because SpatialFullConvolution is performing the adjoint of the forward
     -- convolution operator, we need to swap the forward and backward passes.
-    errcheck('cudnnConvolutionBackwardData', cudnn.getHandle(),
+    errcheck(self,'cudnnConvolutionBackwardData', cudnn.getHandle(),
              cudnn.scalar(input, 1),
              self.weightDesc[0], self.weight:data(),
              self.iDesc[0], input:data(),
-             self.convDesc[0], self.bwdDataAlgType[0],
-             self.extraBuffer:data(), self.extraBufferSizeInBytes,
+             self.convDesc[0], self.bwdDataAlgType,
+             self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
              cudnn.scalar(input, 0),
              self.oDesc[0], self.output:data())
 
     -- add bias
     if self.bias then
-        errcheck('cudnnAddTensor', cudnn.getHandle(),
+        errcheck(self,'cudnnAddTensor', cudnn.getHandle(),
                  cudnn.scalar(input, 1), self.biasDesc[0], self.bias:data(),
                  cudnn.scalar(input, 1), self.oDescForBias[0], self.output:data())
     end
@@ -336,16 +117,19 @@ function SpatialFullConvolution:updateGradInput(input, gradOutput)
 
     assert(gradOutput:dim() == 3 or gradOutput:dim() == 4, 'gradOutput has to be 3D or 4D');
     assert(gradOutput:isContiguous(), 'gradOutput has to be contiguous')
-    if not self.weightDesc then self:resetWeightDescriptors() end
     self:createIODescriptors(input)
+    if not self.fwdDataAlgType then
+       algo.setupForwardAlgorithm(self, {self.oDesc[0], self.output_slice:data(), self.weightDesc[0], self.weight:data(),
+                                         self.convDesc[0], self.iDesc[0], self.input_slice:data() })
+    end
 
-    errcheck('cudnnConvolutionForward', cudnn.getHandle(),
+    errcheck(self,'cudnnConvolutionForward', cudnn.getHandle(),
              cudnn.scalar(input, 1),
              self.oDesc[0], gradOutput:data(),
              self.weightDesc[0], self.weight:data(),
              self.convDesc[0],
-             self.fwdAlgType[0],
-             self.extraBuffer:data(), self.extraBufferSizeInBytes,
+             self.fwdAlgType,
+             self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
              cudnn.scalar(input, 0),
              self.iDesc[0], self.gradInput:data());
     return self.gradInput
@@ -362,12 +146,15 @@ function SpatialFullConvolution:accGradParameters(input, gradOutput, scale)
     assert(gradOutput:dim() == 3 or gradOutput:dim() == 4,
            'gradOutput has to be 3D or 4D');
     assert(gradOutput:isContiguous(), 'gradOutput has to be contiguous')
-    if not self.weightDesc then self:resetWeightDescriptors() end
     self:createIODescriptors(input)
+    if not self.bwdFilterAlgType then
+       algo.setupBackwardFilterAlgorithm(self, {self.oDesc[0], self.output_slice:data(), self.iDesc[0], self.input_slice:data(),
+                                                self.convDesc[0], self.weightDesc[0], self.weight:data()})
+    end
 
     -- gradBias
     if self.bias then
-        errcheck('cudnnConvolutionBackwardBias', cudnn.getHandle(),
+        errcheck(self,'cudnnConvolutionBackwardBias', cudnn.getHandle(),
                  self.scaleT:data(),
                  self.oDescForBias[0], gradOutput:data(),
                  cudnn.scalar(input, 1),
@@ -375,30 +162,19 @@ function SpatialFullConvolution:accGradParameters(input, gradOutput, scale)
     end
 
     -- gradWeight
-    errcheck('cudnnConvolutionBackwardFilter', cudnn.getHandle(),
+    errcheck(self,'cudnnConvolutionBackwardFilter', cudnn.getHandle(),
              self.scaleT:data(),
              self.oDesc[0], gradOutput:data(),
              self.iDesc[0], input:data(),
              self.convDesc[0],
-             self.bwdFilterAlgType[0],
-             self.extraBuffer:data(), self.extraBufferSizeInBytes,
+             self.bwdFilterAlgType,
+             self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize(),
              cudnn.scalar(input, 1),
              self.weightDesc[0], self.gradWeight:data())
 end
 
 function SpatialFullConvolution:clearDesc()
-    self.weightDesc = nil
-    self.biasDesc = nil
-    self.convDesc = nil
-    self.iDesc = nil
-    self.oDesc = nil
-    self.oDescForBias = nil
-    self.algType = nil
-    self.fwdAlgType = nil
-    self.bwdDataAlgType = nil
-    self.bwdFilterAlgType = nil
-    self.extraBuffer = nil
-    self.extraBufferSizeInBytes = nil
+   return Convolution.clearDesc(self)
 end
 
 function SpatialFullConvolution:write(f)

--- a/TemporalConvolution.lua
+++ b/TemporalConvolution.lua
@@ -6,6 +6,8 @@ local TemporalConvolution, parent =
 --it is recommended to pass padding parameter to this routine and use cudnn implicit padding facilities.
 --limitation is that padding will be equal on both sides.
 
+local Convolution = cudnn.SpatialConvolution
+
 function TemporalConvolution:__init(inputFrameSize, outputFrameSize,
                             kH, dH, padH)
     local delayedReset = self.reset
@@ -14,7 +16,7 @@ function TemporalConvolution:__init(inputFrameSize, outputFrameSize,
     local nOutputPlane = outputFrameSize
     self.inputFrameSize = inputFrameSize
     self.outputFrameSize = outputFrameSize
-    cudnn.SpatialConvolution.__init(self, nInputPlane, nOutputPlane, kW, kH, 1, dH,0,padH)
+    Convolution.__init(self, nInputPlane, nOutputPlane, kW, kH, 1, dH,0,padH)
     self.weight = self.weight:view(nOutputPlane,inputFrameSize*kH)
     self.gradWeight = self.gradWeight:view(outputFrameSize, inputFrameSize*kH)
 --self.dW and self.kW now have different meaning than in nn.TemporalConvolution, because
@@ -22,30 +24,19 @@ function TemporalConvolution:__init(inputFrameSize, outputFrameSize,
 end
 
 function TemporalConvolution:createIODescriptors(input)
-    local sizeChanged = false
-    if not self.iDesc or not self.oDesc or
-        input:size(1) ~= self.iSize[1] or input:size(2) ~= self.iSize[2]
-    or input:size(3) ~= self.iSize[3] or input:size(4) ~= self.iSize[4] then
-       sizeChanged = true
-    end
-    cudnn.SpatialConvolution.createIODescriptors(self,input)
-    if sizeChanged then
-       self.oSize = self.output:size()
-    end
+   return Convolution.createIODescriptors(self, input)
 end
 
 function TemporalConvolution:fastest(mode)
-    self = cudnn.SpatialConvolution.fastest(self,mode)
-    return self
+    return Convolution.fastest(self, mode)
 end
 
 function TemporalConvolution:setMode(fmode, bdmode, bwmode)
-    self = cudnn.SpatialConvolution.setMode(self,fmode, bdmode, bwmode)
-    return self
+    return Convolution.setMode(self, fmode, bdmode, bwmode)
 end
 
 function TemporalConvolution:resetWeightDescriptors()
-    cudnn.SpatialConvolution.resetWeightDescriptors(self)
+    return Convolution.resetWeightDescriptors(self)
 end
 
 local function inputview(input)
@@ -63,7 +54,7 @@ function TemporalConvolution:updateOutput(input)
    self._output = self._output or input.new()
    if self.output:storage() then self._output:set(self.output:storage()) else self._output = self.output end
    if self.buffer:storage() then self.output:set(self.buffer:storage(), 1, self.output:size()) else self.output = self.buffer end
-   cudnn.SpatialConvolution.updateOutput(self,_input)
+   Convolution.updateOutput(self, _input)
    self.buffer = self.output:view(self.oSize):transpose(2,3)
    self.output  = self._output:resize(self.buffer:size()):copy(self.buffer)
    -- self.output here is always 4D, use input dimensions to properly view output
@@ -92,7 +83,7 @@ function TemporalConvolution:updateGradInput(input, gradOutput)
    if not self.gradInput then return end
    local _gradOutput = transposeGradOutput(gradOutput,self.buffer)
    local _input = inputview(input)
-   self.gradInput = cudnn.SpatialConvolution.updateGradInput(self,_input, _gradOutput)
+   self.gradInput = Convolution.updateGradInput(self, _input, _gradOutput)
    if input:dim()==3 then
       self.gradInput = self.gradInput:view(self.iSize[1],self.iSize[3],self.iSize[4])
    else
@@ -102,11 +93,11 @@ function TemporalConvolution:updateGradInput(input, gradOutput)
 end
 
 function TemporalConvolution:accGradParameters(input,gradOutput,scale)
-   --2d (4d) view of input
-   local _input = inputview(input)
-   -- transpose gradOutput (it will likely be transposed twice, hopefully, no big deal
+--2d (4d) view of input
+    local _input = inputview(input)
+-- transpose gradOutput (it will likely be transposed twice, hopefully, no big deal
     local _gradOutput = transposeGradOutput(gradOutput,self.buffer)
-    cudnn.SpatialConvolution.accGradParameters(self,_input,_gradOutput,scale)
+    return Convolution.accGradParameters(self,_input,_gradOutput,scale)
 end
 
 function TemporalConvolution:clearDesc()
@@ -130,3 +121,5 @@ function TemporalConvolution:clearState()
    nn.utils.clear(self, '_input', '_gradOutput')
    return parent.clearState(self)
 end
+
+return TemporalConvolution

--- a/algo.lua
+++ b/algo.lua
@@ -1,0 +1,197 @@
+local ffi = require 'ffi'
+
+local algo = {}
+
+algo.findNoExAlgos = {'cudnnFindConvolutionForwardAlgorithm', 'cudnnFindConvolutionBackwardFilterAlgorithm', 'cudnnFindConvolutionBackwardDataAlgorithm'}
+algo.findExAlgos = {'cudnnFindConvolutionForwardAlgorithmEx', 'cudnnFindConvolutionBackwardFilterAlgorithmEx', 'cudnnFindConvolutionBackwardDataAlgorithmEx'}
+
+algo.autotunerCache = {{}, {}, {}}
+algo.findAlgos = nil
+
+local function call(self, f, ...)
+   local status = cudnn.call(f, ...)
+   if cudnn.verbose and status ~= ffi.C.CUDNN_STATUS_SUCCESS then
+      print(f .. " failed for sizes: " .. self.autotunerHash)
+   end
+   return status
+end
+algo.call = call
+
+local function errcheck(self, f, ...)
+   local status = call(self, f, ...)
+   if status ~= ffi.C.CUDNN_STATUS_SUCCESS then
+      local str = ffi.string(cudnn.C.cudnnGetErrorString(status))
+      error('Error in CuDNN: ' .. str .. ' ('..f..')')
+      return false
+   end
+   return true
+end
+algo.errcheck = errcheck
+
+local function initCache(useEx)
+   if useEx then
+      algo.findAlgos = algo.findExAlgos
+   else
+      algo.findAlgos = algo.findNoExAlgos
+   end
+end
+
+local function setupAlgo(self, algo_t, perf_t, findAPI_idx, getAPI, wsAPI, algSearchMode, params)
+        -- recheck if cudnn.useFindEx was reset
+        initCache(cudnn.useFindEx)
+        local findAPI = algo.findAlgos[findAPI_idx]
+        self.extraBuffer = self.extraBuffer or cudnn.getSharedWorkspace()
+        local extraBufferSizeInBytes = self.extraBuffer:nElement() * self.extraBuffer.elementSize()
+        local cachedAlgo = algo.autotunerCache[findAPI_idx][self.autotunerHash]
+        local cacheHit = '[found in cache]'
+        if not cachedAlgo then
+           cacheHit = ''
+           cachedAlgo = {}
+           local perfResults = ffi.new(perf_t, 1)
+           if cudnn.benchmark or cudnn.fastest then -- the manual auto-tuner is run
+              local intt = torch.IntTensor(1)
+              local status
+              if cudnn.useFindEx then
+                 status = algo.call(self, findAPI,
+                                     cudnn.getHandle(),
+                                     params[1], params[2], params[3], params[4], params[5], params[6], params[7],
+                                     1, intt:data(), perfResults, self.extraBuffer:data(), self.extraBuffer:nElement() * self.extraBuffer.elementSize())
+
+              else
+                 status = algo.call(self, findAPI,
+                          cudnn.getHandle(),
+                          params[1], params[3], params[5], params[6],
+                          1, intt:data(), perfResults)
+              end
+
+              if status == ffi.C.CUDNN_STATUS_SUCCESS then
+                 cachedAlgo.algo = tonumber(perfResults[0].algo)
+                 cachedAlgo.memory = tonumber(perfResults[0].memory)
+                 cachedAlgo.time = tonumber(perfResults[0].time)
+                 cachedAlgo.status = tonumber(perfResults[0].status)
+              else
+                 cachedAlgo.algo =0
+                 cachedAlgo.memory = 0
+                 cachedAlgo.time = 0
+                 cachedAlgo.status = tonumber(status)
+              end
+              if cudnn.verbose then
+                 print(string.format(
+                          "\n" .. findAPI .. " Time: %3.5f Memory: %8d Algorithm: %d(out of %d, status: %d)"
+                             .. " hash: %45s",
+                          cachedAlgo.time, cachedAlgo.memory,
+                          cachedAlgo.algo, intt[1], cachedAlgo.status, self.autotunerHash ))
+
+              end
+           else
+              findAPI=getAPI
+              local algType = ffi.new(algo_t, 1)
+              local algWorkspaceLimit = self.workspace_limit
+                 or (self.nInputPlane * self.kH * self.kW * self.weight.elementSize())
+              local status = algo.call(self, getAPI,
+                                       cudnn.getHandle(),
+                                       params[1], params[3], params[5], params[6],
+                                       algSearchMode, algWorkspaceLimit, algType)
+
+
+              if cudnn.verbose then
+                 print(string.format(
+                          "\n" .. getAPI .. ": %d (ws limit: %d) mode = %s status=%d",
+                          tonumber(algType[0]),
+                          algWorkspaceLimit,
+                          algSearchMode, tonumber(status)))
+              end
+
+              if status ~= ffi.C.CUDNN_STATUS_SUCCESS then
+                 cachedAlgo.algo =0
+                 cachedAlgo.memory = 0
+              else
+                 cachedAlgo.algo = tonumber(algType[0])
+                 local bufSize = torch.LongTensor(1)
+                 status = algo.call(self, wsAPI,
+                                    cudnn.getHandle(),
+                                    params[1], params[3], params[5], params[6],
+                                    algType[0], bufSize:data())
+                 if cudnn.verbose then
+                    print(string.format(
+                             "\n" .. wsAPI  .. ": bufSize: %d, current ws: %d, status: %d",
+                             tonumber(bufSize[1]), tonumber(extraBufferSizeInBytes), tonumber(status)))
+                 end
+                 if status ~= ffi.C.CUDNN_STATUS_SUCCESS then
+                    cachedAlgo.memory = 0
+                 else
+                    cachedAlgo.memory = tonumber(bufSize[1])
+                 end
+              end
+           end
+           algo.autotunerCache[findAPI_idx][self.autotunerHash] = cachedAlgo
+        end
+
+        if extraBufferSizeInBytes < cachedAlgo.memory then
+           self.extraBuffer:resize((tonumber(cachedAlgo.memory)+self.extraBuffer.elementSize())/self.extraBuffer.elementSize())
+        end
+
+        if cudnn.verbose then
+           print(string.format(
+                    "\n" .. findAPI  .. ": %d Workspace: %8d  hash: %45s" .. cacheHit,
+                    tonumber(cachedAlgo.algo), tonumber(cachedAlgo.memory), self.autotunerHash))
+        end
+        return cachedAlgo.algo
+end
+
+function algo.prepareHash(self, input_slice, output_slice)
+   local function shape(x)
+      return table.concat(x:size():totable(),'x')
+   end
+   self.autotunerHash = shape(self.weight) .. ';'
+      .. shape(input_slice) .. ';'
+      .. shape(output_slice)
+
+   self.fwdAlgType = nil
+   self.bwdDataAlgType = nil
+   self.bwdFilterAlgType = nil
+   self.input_slice = input_slice
+   self.output_slice = output_slice
+end
+
+function algo.setupForwardAlgorithm(self, params)
+   local algSearchMode
+   if self.fastest_mode  or cudnn.benchmark == true or cudnn.fastest == true then
+      algSearchMode = 'CUDNN_CONVOLUTION_FWD_PREFER_FASTEST'
+   else
+      algSearchMode = 'CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT'
+   end
+
+   params = params or { self.iDesc[0], self.input_slice:data(), self.weightDesc[0], self.weight:data(), self.convDesc[0], self.oDesc[0], self.output_slice:data() }
+   self.fwdAlgType = self.fmode or
+      setupAlgo(self,"cudnnConvolutionFwdAlgo_t[?]", "cudnnConvolutionFwdAlgoPerf_t[?]",
+                1, 'cudnnGetConvolutionForwardAlgorithm',
+                'cudnnGetConvolutionForwardWorkspaceSize', algSearchMode, params)
+end
+
+function algo.setupBackwardFilterAlgorithm(self, params)
+   local algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE'
+   if self.fastest_mode  or cudnn.fastest == true then
+      algSearchMode = 'CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST'
+   end
+   params = params or { self.iDesc[0], self.input_slice:data(), self.oDesc[0], self.output_slice:data(), self.convDesc[0], self.weightDesc[0], self.weight:data() }
+   self.bwdFilterAlgType = self.bwmode or
+      setupAlgo(self,"cudnnConvolutionBwdFilterAlgo_t[?]", "cudnnConvolutionBwdFilterAlgoPerf_t[?]",
+                2, 'cudnnGetConvolutionBackwardFilterAlgorithm',
+                'cudnnGetConvolutionBackwardFilterWorkspaceSize', algSearchMode,
+                params)
+end
+
+function algo.setupBackwardDataAlgorithm(self, params)
+   local algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE'
+   if self.fastest_mode  or cudnn.fastest == true then
+      algSearchMode = 'CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST'
+   end
+   params =  params or { self.weightDesc[0], self.weight:data(), self.oDesc[0], self.output_slice:data(), self.convDesc[0], self.iDesc[0], self.input_slice:data() }
+   self.bwdDataAlgType = self.bdmode or
+      setupAlgo(self,"cudnnConvolutionBwdDataAlgo_t[?]", "cudnnConvolutionBwdDataAlgoPerf_t[?]",
+                3, 'cudnnGetConvolutionBackwardDataAlgorithm',
+                'cudnnGetConvolutionBackwardDataWorkspaceSize', algSearchMode, params)
+end
+
+return algo

--- a/functional.lua
+++ b/functional.lua
@@ -105,7 +105,7 @@ cudnn.functional.Convolution2D_updateOutput = function(handle, input, weight, ou
    local algSearchMode = 'CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT'
    local algWorkspaceLimit = 0
    if workspace then
-       algWorkspaceLimit = workspace:nElement() * 4 -- 4 = sizeof float
+       algWorkspaceLimit = workspace:nElement() * workspace:elementSize()
    end
    errcheck('cudnnGetConvolutionForwardAlgorithm',
             handle,

--- a/test/test.lua
+++ b/test/test.lua
@@ -64,6 +64,16 @@ function torch.CudaDoubleTensor:mean()
    return self:cuda():mean()
 end
 
+-- experiment: what if we return random *even* number for half, random otherwise
+-- did not help this time, but let's keep this manipulation point for the future
+local function random2(min,max)
+   if false then -- testparams.test_type == 'torch.CudaHalfTensor' then
+      return math.ceil((math.random(min,max)+1)/2)
+   else
+      return math.random(min,max)
+   end
+end
+
 local function testLayer(nnlayer, cudnnlayer, input, gradOutput, scale,
                          parametric, batchMode, description)
    description = description or ''
@@ -123,23 +133,23 @@ local function testLayer(nnlayer, cudnnlayer, input, gradOutput, scale,
 end
 
 function cudnntest.SpatialConvolution()
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local to = math.random(1,64)
-   local ki = math.random(1,15)
-   local kj = math.random(1,15)
-   local si = math.random(1,ki)
-   local sj = math.random(1,kj)
-   local outi = math.random(1,64)
-   local outj = math.random(1,64)
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local to = random2(1,64)
+   local ki = random2(1,15)
+   local kj = random2(1,15)
+   local si = random2(1,ki)
+   local sj = random2(1,kj)
+   local outi = random2(1,64)
+   local outj = random2(1,64)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
-   local scale = math.random()
 
    local input = torch.randn(bs,from,inj,ini):cuda()
    local gradOutput = torch.randn(bs,to,outj,outi):cuda()
    local sconv = nn.SpatialConvolution(from,to,ki,kj,si,sj):cuda()
-   local gconv = cast(cudnn.SpatialConvolution(from,to,ki,kj,si,sj)):fastest()
+   local gconv = cast(cudnn.SpatialConvolution(from,to,ki,kj,si,sj))
+
    gconv.weight:copy(sconv.weight)
    gconv.bias:copy(sconv.bias)
 
@@ -154,15 +164,16 @@ function cudnntest.SpatialConvolution()
 end
 
 function cudnntest.SpatialFullConvolution()
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local to = math.random(1,64)
-   local ki = math.random(1,15)
-   local kj = math.random(1,15)
-   local si = math.random(1,ki)
-   local sj = math.random(1,kj)
-   local ini = math.random(1,64)
-   local inj = math.random(1,64)
+
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local to = random2(1,64)
+   local ki = random2(1,15)
+   local kj = random2(1,15)
+   local si = random2(1,ki)
+   local sj = random2(1,kj)
+   local ini = random2(1,64)
+   local inj = random2(1,64)
    local outi = (ini-1)*si+ki
    local outj = (inj-1)*sj+kj
    local scale = math.random()
@@ -185,12 +196,12 @@ function cudnntest.SpatialFullConvolution()
 end
 
 function cudnntest.TemporalConvolution()
-   local bs = math.random(1,32)
-   local inputFrameSize = math.random(1,64)
-   local outputFrameSize = math.random(1,64)
-   local ki = math.random(1,15)
-   local si = math.random(1,ki)
-   local outi = math.random(1,15)
+   local bs = random2(1,32)
+   local inputFrameSize = random2(1,64)
+   local outputFrameSize = random2(1,64)
+   local ki = random2(1,15)
+   local si = random2(1,ki)
+   local outi = random2(1,15)
    local ini = (outi - 1) * si + ki
    local scale = math.random()
 
@@ -207,13 +218,13 @@ function cudnntest.TemporalConvolution()
 end
 
 function cudnntest.TemporalConvolution_padding_batch()
-   local bs = math.random(1,32)
-   local inputFrameSize = math.random(1,64)
-   local outputFrameSize = math.random(1,64)
-   local ki = math.random(2,15)
+   local bs = random2(1,32)
+   local inputFrameSize = random2(1,64)
+   local outputFrameSize = random2(1,64)
+   local ki = random2(2,15)
    local pad_h = math.floor(ki/2)
-   local si = math.random(1,ki)
-   local outi = math.random(2,15)
+   local si = random2(1,ki)
+   local outi = random2(2,15)
    local ini = (outi-1)*si+ki
    local scale = math.random()
 
@@ -261,11 +272,11 @@ function cudnntest.TemporalConvolution_padding_batch()
 end
 
 function cudnntest.TemporalConvolution_reduceBatchSize()
-   local inputFrameSize = math.random(1,64)
-   local outputFrameSize = math.random(1,64)
-   local ki = math.random(1,15)
-   local si = math.random(1,ki)
-   local outi = math.random(1,15)
+   local inputFrameSize = random2(1,64)
+   local outputFrameSize = random2(1,64)
+   local ki = random2(1,15)
+   local si = random2(1,ki)
+   local outi = random2(1,15)
    local ini = (outi-1)*si+ki
    local batchSize = 128
    local smallerBatchSize = batchSize/2
@@ -284,18 +295,18 @@ function cudnntest.TemporalConvolution_reduceBatchSize()
 end
 
 function cudnntest.VolumetricConvolution()
-   local bs = math.random(1,32)
-   local from = math.random(1,16)
-   local to = math.random(1,16)
-   local ki = math.random(3,5)
-   local kj = math.random(3,5)
-   local kk = math.random(3,5)
-   local si = math.random(1,ki-1)
-   local sj = math.random(1,kj-1)
-   local sk = math.random(1,kk-1)
-   local outi = math.random(1,17)
-   local outj = math.random(1,17)
-   local outk = math.random(1,5)
+   local bs = random2(1,32)
+   local from = random2(1,16)
+   local to = random2(1,16)
+   local ki = random2(3,5)
+   local kj = random2(3,5)
+   local kk = random2(3,5)
+   local si = random2(1,ki-1)
+   local sj = random2(1,kj-1)
+   local sk = random2(1,kk-1)
+   local outi = random2(1,17)
+   local outj = random2(1,17)
+   local outk = random2(1,5)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
    local ink = (outk-1)*sk+kk
@@ -319,17 +330,17 @@ function cudnntest.VolumetricConvolution()
 end
 
 function cudnntest.VolumetricMaxPooling()
-   local bs = math.random(1,4)
-   local from = math.random(1,4)
-   local ki = math.random(2,4)
-   local kj = math.random(2,4)
-   local kk = math.random(2,4)
+   local bs = random2(1,4)
+   local from = random2(1,4)
+   local ki = random2(2,4)
+   local kj = random2(2,4)
+   local kk = random2(2,4)
    local si = ki
    local sj = kj
    local sk = kk
-   local outi = math.random(1,64)
-   local outj = math.random(1,64)
-   local outk = math.random(1,64)
+   local outi = random2(1,64)
+   local outj = random2(1,64)
+   local outk = random2(1,64)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
    local ink = (outk-1)*sk+kk
@@ -350,19 +361,19 @@ function cudnntest.VolumetricMaxPooling()
 end
 
 function cudnntest.SpatialMaxPooling()
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local ki = math.random(2,4)
-   local kj = math.random(2,4)
-   local si = math.random(1,4)
-   local sj = math.random(1,4)
-   local outi = math.random(16,64)
-   local outj = math.random(16,64)
-   local padi = math.random(0,ki/2-1)
-   local padj = math.random(0,kj/2-1)
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local ki = random2(2,4)
+   local kj = random2(2,4)
+   local si = random2(1,4)
+   local sj = random2(1,4)
+   local outi = random2(16,64)
+   local outj = random2(16,64)
+   local padi = random2(0,ki/2-1)
+   local padj = random2(0,kj/2-1)
    local ini = (outi-1)*si+ki - padi*2
    local inj = (outj-1)*sj+kj - padj*2
-   local ceil_mode = math.random(0,1) == 1
+   local ceil_mode = random2(0,1) == 1
 
    local input = torch.randn(bs,from,inj,ini):cuda()
    local gradOutput = torch.randn(bs,from,outj,outi):cuda()
@@ -382,14 +393,14 @@ function cudnntest.SpatialMaxPooling()
 end
 
 function cudnntest.SpatialAveragePooling()
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local ki = math.random(2,4)
-   local kj = math.random(2,4)
-   local si = math.random(2,4)
-   local sj = math.random(2,4)
-   local outi = math.random(1,64)
-   local outj = math.random(1,64)
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local ki = random2(2,4)
+   local kj = random2(2,4)
+   local si = random2(2,4)
+   local sj = random2(2,4)
+   local outi = random2(1,64)
+   local outj = random2(1,64)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
 
@@ -411,10 +422,10 @@ function cudnntest.SpatialAveragePooling()
 end
 
 local function nonlin(nonlin, inplace)
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local outi = math.random(1,64)
-   local outj = math.random(1,64)
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local outi = random2(1,64)
+   local outj = random2(1,64)
    local ini = outi
    local inj = outj
 
@@ -457,13 +468,13 @@ function cudnntest.ClippedReLU_single()
 end
 
 function cudnntest.SpatialCrossMapLRN_batch()
-   local bs = math.random(4,10)
-   local inputSize = math.random(6,9)
-   local size = math.random(1,3)*2+1
-   local nbfeatures = math.random(3,8)
-   local alpha = math.random(1,100)/100
-   local beta  = math.random(0,100)/100
-   local k = math.random(1,3)
+   local bs = random2(4,10)
+   local inputSize = random2(6,9)
+   local size = random2(1,3)*2+1
+   local nbfeatures = random2(3,8)
+   local alpha = random2(1,100)/100
+   local beta  = random2(0,100)/100
+   local k = random2(1,3)
 
    local input = torch.rand(bs, nbfeatures, inputSize, inputSize):cuda()
    local gradOutput = torch.rand(input:size()):cuda()
@@ -481,8 +492,8 @@ function cudnntest.SpatialCrossMapLRN_batch()
 end
 
 function cudnntest.SoftMax_single()
-   local bs = math.random(1, 32)
-   local sz = math.random(1,64)
+   local bs = random2(1, 32)
+   local sz = random2(1,64)
    local input = torch.randn(bs, sz):cuda()
    local gradOutput = torch.randn(bs, sz):cuda()
 
@@ -504,8 +515,8 @@ function cudnntest.SoftMax_single()
 end
 
 function cudnntest.LogSoftMax()
-   local bs = math.random(1, 32)
-   local sz = math.random(1,64)
+   local bs = random2(1, 32)
+   local sz = random2(1,64)
    local input = torch.randn(bs, sz):cuda()
    local gradOutput = torch.randn(bs, sz):cuda()
 
@@ -528,10 +539,10 @@ end
 
 function cudnntest.SpatialLogSoftMax()
     -- batch
-    local numLabels = math.random(5,10)
-    local h = math.random(5,10)
-    local w = math.random(5,10)
-    local bsz = math.random(3, 7)
+    local numLabels = random2(5,10)
+    local h = random2(5,10)
+    local w = random2(5,10)
+    local bsz = random2(3, 7)
     local input = torch.zeros(bsz, numLabels, h, w):normal():cuda()
     local target = torch.zeros(bsz, numLabels, h, w):normal():cuda()
 
@@ -619,29 +630,29 @@ end
 
 function cudnntest.BatchNormalization()
    local size = {
-      math.random(2, 32),
-      math.random(16, 256),
+      random2(2, 32),
+      random2(16, 256),
    }
    testBatchNormalization('BatchNormalization', size)
 end
 
 function cudnntest.SpatialBatchNormalization()
    local size = {
-      math.random(1, 32),
-      math.random(1, 32),
-      math.random(5, 10),
-      math.random(5, 10),
+      random2(1, 32),
+      random2(1, 32),
+      random2(5, 10),
+      random2(5, 10),
    }
    testBatchNormalization('SpatialBatchNormalization', size)
 end
 
 function cudnntest.VolumetricBatchNormalization()
    local size = {
-      math.random(1, 32),
-      math.random(1, 32),
-      math.random(2, 6),
-      math.random(2, 6),
-      math.random(2, 6),
+      random2(1, 32),
+      random2(1, 32),
+      random2(2, 6),
+      random2(2, 6),
+      random2(2, 6),
    }
    testBatchNormalization('VolumetricBatchNormalization', size)
 end
@@ -649,10 +660,10 @@ end
 function cudnntest.SpatialCrossEntropyCriterion()
     if testparams.test_type ~= 'torch.CudaTensor' then return end
     -- batch
-    local numLabels = math.random(5,10)
-    local h = math.random(5,10)
-    local w = math.random(5,10)
-    local bsz = math.random(3, 7)
+    local numLabels = random2(5,10)
+    local h = random2(5,10)
+    local w = random2(5,10)
+    local bsz = random2(3, 7)
     local input = torch.zeros(bsz, numLabels, h, w):normal():cuda()
     local target = torch.Tensor(bsz, h, w):random(1, numLabels):cuda()
 
@@ -684,15 +695,15 @@ function cudnntest.SpatialCrossEntropyCriterion()
 end
 
 function cudnntest.functional_bias2D()
-   local bs = math.random(1,32)
-   local from = math.random(1,32)
-   local to = math.random(1,64)
-   local ki = math.random(1,15)
-   local kj = math.random(1,15)
-   local si = math.random(1,ki)
-   local sj = math.random(1,kj)
-   local outi = math.random(1,64)
-   local outj = math.random(1,64)
+   local bs = random2(1,32)
+   local from = random2(1,32)
+   local to = random2(1,64)
+   local ki = random2(1,15)
+   local kj = random2(1,15)
+   local si = random2(1,ki)
+   local sj = random2(1,kj)
+   local outi = random2(1,64)
+   local outj = random2(1,64)
    local ini = (outi-1)*si+ki
    local inj = (outj-1)*sj+kj
    local scale = torch.uniform()
@@ -773,7 +784,11 @@ math.randomseed(os.time())
 mytester = torch.Tester()
 mytester:add(cudnntest)
 
-for i = 1, 1 do -- cutorch.getDeviceCount() do
+-- new flag to use FindEx instead of Find : disabled as we encounter errors.
+cudnn.useFindEx=false
+cudnn.verbose=false
+
+for i = 1, cutorch.getDeviceCount() do
    for _, benchmark in ipairs({false, true}) do
       cudnn.benchmark = benchmark
 
@@ -792,16 +807,16 @@ for i = 1, 1 do -- cutorch.getDeviceCount() do
       testparams = testparams_double
       mytester:run()
 
+
       print(
          [[Half Tensor tests are disabled due to missing functionality.
 They will be enabled once fully fixed and functional.
 See https://github.com/soumith/cudnn.torch/issues/225 for progress
 ]])
       -- Developers, do not commit uncommented regions until bindings fixed
-      -- print'Testing torch.CudaHalfTensor'
-      -- testparams = testparams_half
-      -- mytester:run()
-
+--      print'Testing torch.CudaHalfTensor'
+--      testparams = testparams_half
+--      mytester:run()
    end
 end
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -784,12 +784,12 @@ math.randomseed(os.time())
 mytester = torch.Tester()
 mytester:add(cudnntest)
 
--- new flag to use FindEx instead of Find : disabled as we encounter errors.
-cudnn.useFindEx=false
+-- new flag to use FindEx instead of Find
+cudnn.useFindEx=true
 cudnn.verbose=false
 
 for i = 1, cutorch.getDeviceCount() do
-   for _, benchmark in ipairs({false, true}) do
+   for _, benchmark in ipairs({false,true}) do
       cudnn.benchmark = benchmark
 
       local prop = cutorch.getDeviceProperties(i)


### PR DESCRIPTION
Here's take 2 on CUDNN Find refactoring. Important additions:
- cached algos and sizes are used for both Get and Find calls
- Improved error diagnostic and some instrumentation to investigate Half failures.
- Added FindEx capability: this new mode is supposed to be more memory efficient. It is very tricky to use though and would require some elaborate workspace storage management, so for now I have put it into unreachable fallback to Find, until at least we have a decent memory pool in place.

I have tested this PR extensively: 
Find and Get options work fine. Tried to fix FP16 tests using CUDNN team suggestions: still unstable.
