### PR TITLE
patches for Windows

### DIFF
--- a/ffi.lua
+++ b/ffi.lua
@@ -1592,7 +1592,7 @@ if CUDNN_PATH then
     cudnn.C = ffi.load(CUDNN_PATH)
 else
 
-    local libnames = {'libcudnn.so.5', 'libcudnn.5.dylib'}
+    local libnames = {'libcudnn.so.5', 'libcudnn.5.dylib', 'cudnn64_5.dll'}
     local ok = false
     for i=1,#libnames do
         ok = pcall(function () cudnn.C = ffi.load(libnames[i]) end)

--- a/find.lua
+++ b/find.lua
@@ -537,12 +537,13 @@ function find:prepare(layer, input_slice, output_slice)
 end
 
 local function setupWS(layer, params, algo, fn)
-     local bufSize = torch.LongTensor(1)
+     local bufSizeptr = ffi.new("size_t[1]")
      cudnn.errcheck(getWSAlgos[fn],
                                      cudnn.getHandle(),
                                      params[1], params[3], layer.convDesc[0], params[6],
-                                     algo, bufSize:data())
-     cudnn.setSharedWorkspaceSize(bufSize[1], true)
+                                     algo, bufSizeptr)
+     local bufSize = tonumber(bufSizeptr[0])                 
+     cudnn.setSharedWorkspaceSize(bufSize, true)
 end
 
 

--- a/find.lua
+++ b/find.lua
@@ -375,21 +375,23 @@ function find:setupAlgo(layer, findAPI_idx, algSearchMode, params)
                                 algWorkspaceLimit,
                                 algSearchMode))
                     end
-                    local bufSize = torch.LongTensor(1)
+                    local bufSizeptr = ffi.new("size_t[1]")
                     ret = cudnn.call(getWSAlgos[findAPI_idx],
                                      cudnn.getHandle(),
                                      params[1], params[3], layer.convDesc[0], params[6],
-                                     retAlgo, bufSize:data())
+                                     retAlgo, bufSizeptr)
+                    local bufSize = tonumber(bufSizeptr[0])                 
+  
                     if ret ~= 0 then
                        return ret
                     end
                     if find.verbose then
                        print(string.format(
                                 "\n" .. getWSAlgos[findAPI_idx]  .. ": bufSize: %d, current ws: %d",
-                                tonumber(bufSize[1]), tonumber(curWorkspaceSize)))
+                                bufSize, tonumber(curWorkspaceSize)))
                     end
                     perfResults[0].algo = retAlgo
-                    perfResults[0].memory = bufSize[1]
+                    perfResults[0].memory = bufSize
                     perfResults[0].status = ret
                  end
               end

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,8 @@ require('cudnn.ffi')
 local C = cudnn.C
 local ffi = require 'ffi'
 
+local thc = ffi.load("THC")
+
 --------------------------------------------------------------------
 -- defaults, each should be overrideable via env var:
 --------------------------------------------------------------------
@@ -148,7 +150,7 @@ end
 
 function cudnn.call(f, ...)
     C.cudnnSetStream(cudnn.getHandle(),
-                     ffi.C.THCState_getCurrentStream(cutorch.getState()))
+                     thc.THCState_getCurrentStream(cutorch.getState()))
     return C[f](...)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,8 @@ require('cudnn.ffi')
 local C = cudnn.C
 local ffi = require 'ffi'
 
-local thc = ffi.load("THC")
+local thc = ffi.C
+if ffi.os == "Windows" then thc = ffi.load("THC") end
 
 --------------------------------------------------------------------
 -- defaults, each should be overrideable via env var:


### PR DESCRIPTION
With these patches, i was able to run the test script below on Windows, using CUDA 8 and cudnn 5.1. The file RNN.lua would also need to be patched to avoid the LongTensor issue.


require "torch"
local cudnn = require 'cudnn'

local X = torch.rand(320, 3, 240, 240):cuda()
local net = nn.Sequential()
net:add(cudnn.SpatialConvolution(3, 8, 5, 5))
net:cuda()

local output = net:forward(X)
