### PR TITLE
storageOffset is calculated in element not bytes

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -613,7 +613,7 @@ local function retrieveLinearParams(self, cuDNNMethod)
                 nbDims:data(),
                 filterDimA:data())
 
-            local offset = tonumber(matrixPointer[0]) - tonumber(self.weight:data())
+            local offset = (tonumber(matrixPointer[0]) - tonumber(self.weight:data()))/self.weight:elementSize()
             local params = torch.CudaTensor(self.weight:storage(), offset + self.weight:storageOffset(), filterDimA:prod())
             table.insert(layerInfo, params)
         end


### PR DESCRIPTION
Sorry - there was also missing division by element size in the fix.
thanks.

this fixes: https://github.com/soumith/cudnn.torch/issues/322
