### PR TITLE
inplace tests for Sigmoid and Tanh, typo

### DIFF
--- a/find.lua
+++ b/find.lua
@@ -110,7 +110,7 @@ local function fallbackWarning(layer, msg)
             "\n *** Falling back to 32-bit math for: " .. convDataString(layer))
       print(" *** [ Set cudnn.find.verboseFallback to false to disable this message ] *** ")
       print(" *** [ Alternatively, you may force CUDNN to always operate on CudaHalfTensors via 32-bit float conversion, in Lua: ] ***\n"
-               .." *** [ cudnn.configureMath({ ['torch.CudaHalfTensor']   = 'CUDNN_DATA_FLOAT'} ] ***")
+               .." ***  cudnn.configureMath({ ['torch.CudaHalfTensor']   = 'CUDNN_DATA_FLOAT'} ) ***")
       print(" *** [ Note: result may be faster or slower than native FP16, depending on your GPU and CUDNN operations ] *** ")
    end
 end

--- a/test/test.lua
+++ b/test/test.lua
@@ -77,9 +77,10 @@ local function testLayer(nnlayer, cudnnlayer, input, gradOutput, scale,
    end
 
    local res = {} -- result
-   res.output = cudnnlayer:forward(cast(input))
+   inputcudnn = cast(input):clone() -- for inplace layers
+   res.output = cudnnlayer:forward(inputcudnn)
    cudnnlayer:zeroGradParameters()
-   res.gradInput = cudnnlayer:backward(cast(input), cast(gradOutput), scale)
+   res.gradInput = cudnnlayer:backward(inputcudnn, cast(gradOutput), scale)
    if parametric then
       res.gradWeight = cudnnlayer.gradWeight
       res.gradBias = cudnnlayer.gradBias
@@ -472,9 +473,11 @@ function cudnntest.ReLU()
    nonlin('ReLU', false) -- out of place
 end
 function cudnntest.Tanh()
+   nonlin('Tanh', true) -- inplace
    nonlin('Tanh', false) -- out of place
 end
 function cudnntest.Sigmoid()
+   nonlin('Sigmoid', true) -- inplace
    nonlin('Sigmoid', false) -- out of place
 end
 
@@ -943,7 +946,7 @@ cudnn.find.verbose=false
 -- this is the default, keep it for demo of 16->32 bit float fallback
 cudnn.find.verboseFallback=true
 cudnn.useFindEx=false
-
+cudnn.configureMath({ ['torch.CudaHalfTensor']   = 'CUDNN_DATA_FLOAT'} )
 for i = 1, 1 do -- cutorch.getDeviceCount() do
 
    for _, benchmark, fast in ipairs({true, false}) do


### PR DESCRIPTION
supersedes #329, depends on #1135 in nn for the tests to actually pass. 