### PR TITLE
Fixed version collision case

### DIFF
--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -62,7 +62,7 @@ function(CUDNN_INSTALL version dest_libdir dest_incdir dest_bindir)
   
   # Download and install CUDNN locally if not found on the system
   if(url_arch_name) 
-    set(download_dir ${CMAKE_CURRENT_BINARY_DIR}/downloads)
+    set(download_dir ${CMAKE_CURRENT_BINARY_DIR}/downloads/cudnn${version})
     file(MAKE_DIRECTORY ${download_dir})
     set(cudnn_filename cudnn-${CUDA_VERSION}-${url_arch_name}-v${version}.tgz)
     set(base_url http://developer.download.nvidia.com/compute/redist/cudnn)


### PR DESCRIPTION
This would only matter for core developers, switching from R6 to master back and forth _and_ having cudnn locally installed. Still, I stumbled upon it.