### PR TITLE
WIP: variable length sequences for RNNs

### DIFF
--- a/test/test_rnn.lua
+++ b/test/test_rnn.lua
@@ -409,6 +409,8 @@ function rnntest.testVariableLengthSequences()
    local packed = cudnn.RNN:packPaddedSequence(input, lengths)
    local packedOutput = lstm:updateOutput(packed)
    local packedHiddenOutput = lstm.hiddenOutput:clone()
+   -- could use padPackedSequence here, but for testing simplicity, we'll just
+   -- operate on the returned results
 
    local separate = {}
    local hids = {}
@@ -467,6 +469,9 @@ function rnntest.testVariableLengthSequences()
       local diff = torch.csub(igiTestable[sep], packedGradInput[batched]):abs():sum()
       mytester:assert(diff < 1e-7)
    end
+
+   -- Step 3: Basically verify that accGradParameters works for batch
+   lstm:accGradParameters(packed, gradOutput)
 end
 
 mytester = torch.Tester()

--- a/test/test_rnn.lua
+++ b/test/test_rnn.lua
@@ -451,7 +451,7 @@ function cudnntest.testVariableLengthSequences()
       {11, 4}
    }
    for _, pair in ipairs(corresponding) do
-      sep, batched = unpack(pair)
+      local sep, batched = unpack(pair)
       local diff = torch.csub(separate[sep], packedOutput[batched]):abs():sum()
       mytester:assert(diff < 1e-7)
    end

--- a/test/test_rnn.lua
+++ b/test/test_rnn.lua
@@ -321,7 +321,7 @@ local function deepcopyRNN(dest, src)
    dest.gradWeight = src.gradWeight:clone()
 end
 
-function rnntest.testVariableLengthSequences()
+function cudnntest.testVariableLengthSequences()
    local input = torch.CudaTensor({
       {{1, 2, 2, 1},
        {2, 1, 2, 2},
@@ -475,5 +475,5 @@ function rnntest.testVariableLengthSequences()
 end
 
 mytester = torch.Tester()
-mytester:add(rnntest)
+mytester:add(cudnntest)
 mytester:run()


### PR DESCRIPTION
Analogous to https://github.com/pytorch/pytorch/pull/873

- Pass variable length sequences to RNN forward/backward passes
- Utility functions to handle padded and packed sequences of this nature