### PR TITLE
eliminate unnecessary descriptor reset in RNN forward pass

### DIFF
--- a/RNN.lua
+++ b/RNN.lua
@@ -264,7 +264,6 @@ function RNN:updateOutput(input)
 
    if input:size(1) ~= self.seqLength then
       self.seqLength = input:size(1)
-      resetRNN = true
       resetIO = true
    end
 


### PR DESCRIPTION
Changing the seqLength parameter should not trigger a reset of the RNN descriptor because this parameter is not used in that descriptor.