### PR TITLE
Fix SpatialDilatedConvolution:reset()

### DIFF
--- a/SpatialDilatedConvolution.lua
+++ b/SpatialDilatedConvolution.lua
@@ -5,8 +5,6 @@ local find = require 'cudnn.find'
 
 function SpatialDilatedConvolution:__init(nInputPlane, nOutputPlane,
                             kW, kH, dW, dH, padW, padH, dilationW, dilationH, groups)
-    local delayedReset = self.reset
-    self.reset = function() end
     parent.__init(self, nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH, groups)--, dilationW, dilationH)
     self.dilationW = dilationW
     self.dilationH = dilationH


### PR DESCRIPTION
SpatialDilatedConvolution:reset () is not called.
The following line calls the empty function.
https://github.com/soumith/cudnn.torch/blob/d7a5a86b96c60cab4e36c74aae1c3155bd0ba580/SpatialConvolution.lua#L23 
This PR fixes that issue.

Is this intended?
