### PR TITLE
Fix backward compatibility problem due to groups

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -29,6 +29,7 @@ end
 function SpatialConvolution:resetWeightDescriptors(desc)
     assert(cudnn.typemap[torch.typename(self.weight)], 'Only Cuda supported duh!')
     assert(cudnn.typemap[torch.typename(self.bias)] or not self.bias, 'Only Cuda supported duh!')
+    self.groups = self.groups or 1
 
     -- create descriptor for bias
     if self.bias then

--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -27,6 +27,7 @@ function SpatialFullConvolution:__init(nInputPlane, nOutputPlane,
 end
                                                             
 function SpatialFullConvolution:resetWeightDescriptors()
+   self.groups = self.groups or 1
    return Convolution.resetWeightDescriptors(self, {self.nInputPlane,
                                                     self.nOutputPlane/self.groups,
                                                     self.kH, self.kW})


### PR DESCRIPTION
Older pre-trained models do not have `groups`.
This fix has been deleted in 84811a509c2bef04909d1b36cfe1375aaef3181f but it is necessary.